### PR TITLE
feat: add typed held-out KG runner (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,32 @@ Generated files:
 - `heldout_selected_settings.json`
 - `heldout_selection_manifest.md`
 
+## Held-Out KG Runner
+
+Use the dedicated held-out KG runner to evaluate frozen TF-IDF and BM25 settings by
+entity type across `heldout_datasets`.
+
+With latest selected-settings artifact (auto-detected):
+
+```bash
+python -m src.main run-heldout-kg
+```
+
+With explicit selected-settings artifact and config path:
+
+```bash
+python -m src.main run-heldout-kg --config-path config/runtime.yaml --selected-settings-json results/comparisons/result_YYYYMMDD_HHMMSS_<gitsha>/heldout_selected_settings.json
+```
+
+The held-out KG results CSV includes:
+
+- `entity_type`
+- `target_pool_size`
+- `retained_candidate_size`
+- `candidate_reduction_ratio`
+- fixed `recall_at_<k>` columns
+- `mrr`
+
 ## Logging
 
 Experiment logs are written to timestamped files under `logs/`:

--- a/src/experiments/heldout_kg_runner.py
+++ b/src/experiments/heldout_kg_runner.py
@@ -1,0 +1,433 @@
+"""Held-out KG experiment runner with typed partitions and frozen settings."""
+
+from __future__ import annotations
+
+import csv
+from datetime import datetime
+import json
+import logging
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import TypedDict, cast
+
+from tqdm import tqdm
+
+from src.config_loader import load_runtime_config
+from src.evaluation.metrics import compute_recall_at_ks_and_mrr
+from src.experiments.experiment_runner import _load_store_with_fallback
+from src.preprocessing.text_preprocessor import preprocess_text, validate_nltk_assets
+from src.rdf_utils.alignment_parser import load_alignment_mappings
+from src.rdf_utils.entity_partitioning import (
+    EntityType,
+    TypedAlignmentPartitions,
+    TypedEntityPartitions,
+    extract_typed_entity_partitions,
+    partition_alignment_mappings_by_entity_type,
+)
+from src.rdf_utils.label_extractor import extract_entity_label
+from src.retrieval.bm25_retriever import Bm25Retriever
+from src.retrieval.tfidf_retriever import TfidfRetriever
+
+logger = logging.getLogger(__name__)
+
+FIXED_CSV_COLUMNS: tuple[str, ...] = (
+    "track",
+    "version",
+    "dataset",
+    "entity_type",
+    "method",
+    "hyperparameters",
+    "gold_count",
+    "target_pool_size",
+    "retained_candidate_size",
+    "candidate_reduction_ratio",
+    "mrr",
+    "runtime_seconds",
+)
+
+
+class HeldoutKgRunnerValidationError(ValueError):
+    """Raised when held-out KG execution inputs are invalid."""
+
+
+class HeldoutKgResultRecord(TypedDict):
+    dataset_name: str
+    track: str
+    version: str
+    entity_type: str
+    model: str
+    hyperparameters: dict[str, object]
+    gold_count: int
+    target_pool_size: int
+    retained_candidate_size: int
+    candidate_reduction_ratio: float
+    recalls: dict[int, float]
+    mrr: float
+    runtime_seconds: float
+
+
+def _get_git_short_sha() -> str:
+    repo_root = Path(__file__).resolve().parents[2]
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=repo_root,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (subprocess.SubprocessError, OSError):
+        return "nogit"
+
+
+def _default_output_csv_path() -> Path:
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    git_sha = _get_git_short_sha()
+    return Path("results") / f"heldout_result_{timestamp}_{git_sha}.csv"
+
+
+def _resolve_selected_settings_json(
+    selected_settings_path: str | Path | None,
+) -> Path:
+    if selected_settings_path is not None:
+        path = Path(selected_settings_path).resolve()
+        if not path.exists():
+            raise FileNotFoundError(f"Selected settings JSON not found: {path}")
+        return path
+
+    candidates = sorted(
+        Path("results/comparisons").glob("**/heldout_selected_settings.json"),
+        key=lambda candidate: candidate.stat().st_mtime,
+    )
+    if not candidates:
+        raise FileNotFoundError(
+            "No results/comparisons/**/heldout_selected_settings.json files found."
+        )
+    return candidates[-1].resolve()
+
+
+def _load_selected_settings(selected_settings_path: Path) -> dict[str, dict[str, object]]:
+    try:
+        payload = json.loads(selected_settings_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise HeldoutKgRunnerValidationError(
+            f"Malformed selected settings JSON: {selected_settings_path}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise HeldoutKgRunnerValidationError(
+            f"Selected settings payload must be a JSON object: {selected_settings_path}"
+        )
+    selected_settings = payload.get("selected_settings")
+    if not isinstance(selected_settings, dict):
+        raise HeldoutKgRunnerValidationError(
+            "Selected settings JSON must contain a 'selected_settings' object."
+        )
+
+    required_hyperparameter_keys = {
+        "tfidf": ("ngram_range", "min_df", "max_df", "sublinear_tf"),
+        "bm25": ("k1", "b"),
+    }
+
+    resolved: dict[str, dict[str, object]] = {}
+    for method in ("tfidf", "bm25"):
+        entry = selected_settings.get(method)
+        if not isinstance(entry, dict):
+            raise HeldoutKgRunnerValidationError(
+                f"Selected settings JSON missing required method '{method}'."
+            )
+        hyperparameters = entry.get("hyperparameters")
+        if not isinstance(hyperparameters, dict):
+            raise HeldoutKgRunnerValidationError(
+                f"Selected settings for method '{method}' must include a hyperparameters object."
+            )
+        missing = [
+            key for key in required_hyperparameter_keys[method] if key not in hyperparameters
+        ]
+        if missing:
+            missing_str = ", ".join(missing)
+            raise HeldoutKgRunnerValidationError(
+                f"Selected settings for method '{method}' missing required hyperparameter keys: {missing_str}."
+            )
+        resolved[method] = hyperparameters
+
+    logger.info(
+        "Loaded frozen held-out settings from %s (tfidf=%s, bm25=%s)",
+        selected_settings_path,
+        json.dumps(resolved["tfidf"], sort_keys=True, separators=(",", ":")),
+        json.dumps(resolved["bm25"], sort_keys=True, separators=(",", ":")),
+    )
+    return resolved
+
+
+def _build_labels(store, entity_ids: list[str]) -> list[str]:
+    return [extract_entity_label(store, uri) for uri in entity_ids]
+
+
+def _preprocess_labels(labels: list[str]) -> tuple[list[list[str]], list[str]]:
+    tokenized = [preprocess_text(label) for label in labels]
+    joined = [" ".join(tokens) for tokens in tokenized]
+    return tokenized, joined
+
+
+def _build_csv_columns(evaluation_ks: list[int]) -> list[str]:
+    return [
+        *FIXED_CSV_COLUMNS[:10],
+        *(f"recall_at_{k}" for k in evaluation_ks),
+        *FIXED_CSV_COLUMNS[10:],
+    ]
+
+
+def _persist_results_to_csv(
+    results: list[HeldoutKgResultRecord],
+    output_csv_path: str | Path,
+    evaluation_ks: list[int],
+) -> None:
+    csv_columns = _build_csv_columns(evaluation_ks)
+    output_path = Path(output_csv_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with output_path.open("w", encoding="utf-8", newline="") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=csv_columns)
+        writer.writeheader()
+        for record in results:
+            row: dict[str, object] = {
+                "track": record["track"],
+                "version": record["version"],
+                "dataset": record["dataset_name"],
+                "entity_type": record["entity_type"],
+                "method": record["model"],
+                "hyperparameters": json.dumps(
+                    record["hyperparameters"], sort_keys=True, separators=(",", ":")
+                ),
+                "gold_count": record["gold_count"],
+                "target_pool_size": record["target_pool_size"],
+                "retained_candidate_size": record["retained_candidate_size"],
+                "candidate_reduction_ratio": record["candidate_reduction_ratio"],
+                "mrr": record["mrr"],
+                "runtime_seconds": record["runtime_seconds"],
+            }
+            for k in evaluation_ks:
+                row[f"recall_at_{k}"] = record["recalls"][k]
+            writer.writerow(row)
+
+
+def _entity_values(partitions: TypedEntityPartitions, entity_type: EntityType) -> tuple[str, ...]:
+    if entity_type is EntityType.CLASS:
+        return partitions.classes
+    if entity_type is EntityType.PREDICATE:
+        return partitions.predicates
+    return partitions.instances
+
+
+def _gold_values(
+    partitions: TypedAlignmentPartitions,
+    entity_type: EntityType,
+) -> dict[str, str]:
+    if entity_type is EntityType.CLASS:
+        return partitions.classes
+    if entity_type is EntityType.PREDICATE:
+        return partitions.predicates
+    return partitions.instances
+
+
+def _validate_type_partition(
+    *,
+    dataset_name: str,
+    entity_type: EntityType,
+    target_entities: tuple[str, ...],
+    gold: dict[str, str],
+) -> None:
+    if not target_entities:
+        raise HeldoutKgRunnerValidationError(
+            f"Held-out dataset '{dataset_name}' has zero target entities for entity type '{entity_type.value}'."
+        )
+    if not gold:
+        raise HeldoutKgRunnerValidationError(
+            f"Held-out dataset '{dataset_name}' has zero gold mappings for entity type '{entity_type.value}'."
+        )
+
+
+def run_heldout_kg_experiments(
+    config_path: str | Path = "config/runtime.yaml",
+    selected_settings_path: str | Path | None = None,
+    output_csv_path: str | Path | None = None,
+    show_progress: bool | None = None,
+) -> list[HeldoutKgResultRecord]:
+    """Run frozen TF-IDF and BM25 held-out KG evaluation by entity type."""
+    validate_nltk_assets()
+    progress_enabled = sys.stderr.isatty() if show_progress is None else show_progress
+    resolved_output_csv_path = (
+        Path(output_csv_path) if output_csv_path is not None else _default_output_csv_path()
+    )
+    runtime_config = load_runtime_config(config_path=config_path, require_heldout=True)
+    selected_settings_json = _resolve_selected_settings_json(selected_settings_path)
+    frozen_settings = _load_selected_settings(selected_settings_json)
+    datasets = runtime_config.heldout_datasets
+    if not datasets:
+        raise HeldoutKgRunnerValidationError(
+            "Held-out KG execution requires at least one heldout_datasets entry."
+        )
+
+    evaluation_ks = runtime_config.experiments.evaluation_ks
+    k_max = max(evaluation_ks)
+    logger.info(
+        "Starting held-out KG run with config=%s selected_settings=%s output_csv_path=%s progress=%s",
+        config_path,
+        selected_settings_json,
+        resolved_output_csv_path,
+        progress_enabled,
+    )
+
+    results: list[HeldoutKgResultRecord] = []
+    dataset_names = list(datasets.keys())
+    dataset_iterator = tqdm(
+        dataset_names,
+        desc="HeldoutDatasets",
+        disable=not progress_enabled,
+    )
+
+    for dataset_name in dataset_iterator:
+        dataset = datasets[dataset_name]
+        logger.info(
+            "Processing held-out dataset '%s' (track=%s, version=%s)",
+            dataset_name,
+            dataset.track,
+            dataset.version,
+        )
+        source_store = _load_store_with_fallback(dataset.source_rdf)
+        target_store = _load_store_with_fallback(dataset.target_rdf)
+        gold_raw = load_alignment_mappings(dataset.alignment_rdf)
+        source_partitions = extract_typed_entity_partitions(
+            source_store,
+            graph_name=f"{dataset_name}:source",
+        )
+        target_partitions = extract_typed_entity_partitions(
+            target_store,
+            graph_name=f"{dataset_name}:target",
+        )
+        gold_partitions = partition_alignment_mappings_by_entity_type(
+            gold_raw,
+            source_partitions,
+            target_partitions,
+            alignment_name=dataset_name,
+        )
+
+        for entity_type in (EntityType.CLASS, EntityType.PREDICATE, EntityType.INSTANCE):
+            target_entities = list(_entity_values(target_partitions, entity_type))
+            gold = _gold_values(gold_partitions, entity_type)
+            _validate_type_partition(
+                dataset_name=dataset_name,
+                entity_type=entity_type,
+                target_entities=tuple(target_entities),
+                gold=gold,
+            )
+
+            eval_sources = sorted(gold.keys())
+            target_labels = _build_labels(target_store, target_entities)
+            source_labels = _build_labels(source_store, eval_sources)
+            target_tokens, target_labels_preprocessed = _preprocess_labels(target_labels)
+            source_tokens, source_labels_preprocessed = _preprocess_labels(source_labels)
+            source_label_preprocessed_map = dict(
+                zip(eval_sources, source_labels_preprocessed, strict=True)
+            )
+            source_token_map = dict(zip(eval_sources, source_tokens, strict=True))
+            target_pool_size = len(target_entities)
+            retained_candidate_size = min(k_max, target_pool_size)
+            candidate_reduction_ratio = 1.0 - (
+                retained_candidate_size / target_pool_size
+            )
+
+            logger.info(
+                "Held-out dataset '%s' entity_type=%s setup: target_pool_size=%d gold_count=%d retained_candidate_size=%d reduction_ratio=%.6f",
+                dataset_name,
+                entity_type.value,
+                target_pool_size,
+                len(gold),
+                retained_candidate_size,
+                candidate_reduction_ratio,
+            )
+
+            for method_name in ("tfidf", "bm25"):
+                hyperparameters = frozen_settings[method_name]
+                run_start = time.perf_counter()
+                logger.info(
+                    "Running held-out dataset='%s' entity_type=%s method=%s hyperparameters=%s",
+                    dataset_name,
+                    entity_type.value,
+                    method_name,
+                    hyperparameters,
+                )
+                if method_name == "tfidf":
+                    retriever = TfidfRetriever(
+                        ngram_range=tuple(cast(list[int], hyperparameters["ngram_range"])),
+                        min_df=cast(int | float, hyperparameters["min_df"]),
+                        max_df=cast(int | float, hyperparameters["max_df"]),
+                        sublinear_tf=cast(bool, hyperparameters["sublinear_tf"]),
+                    )
+                    retriever.fit_preprocessed(target_entities, target_labels_preprocessed)
+                    predictions = {
+                        source_id: retriever.retrieve_preprocessed(
+                            source_label_preprocessed_map[source_id],
+                            k=k_max,
+                        )
+                        for source_id in eval_sources
+                    }
+                else:
+                    retriever = Bm25Retriever(
+                        k1=float(cast(int | float, hyperparameters["k1"])),
+                        b=float(cast(int | float, hyperparameters["b"])),
+                    )
+                    retriever.fit_tokenized(target_entities, target_tokens)
+                    predictions = {
+                        source_id: retriever.retrieve_tokenized(
+                            source_token_map[source_id],
+                            k=k_max,
+                        )
+                        for source_id in eval_sources
+                    }
+
+                raw_recalls, mrr = compute_recall_at_ks_and_mrr(
+                    predictions, gold, evaluation_ks
+                )
+                recalls = {k: raw_recalls[k] for k in evaluation_ks}
+                results.append(
+                    HeldoutKgResultRecord(
+                        dataset_name=dataset.name,
+                        track=dataset.track,
+                        version=dataset.version,
+                        entity_type=entity_type.value,
+                        model=method_name,
+                        hyperparameters=hyperparameters,
+                        gold_count=len(gold),
+                        target_pool_size=target_pool_size,
+                        retained_candidate_size=retained_candidate_size,
+                        candidate_reduction_ratio=candidate_reduction_ratio,
+                        recalls=recalls,
+                        mrr=mrr,
+                        runtime_seconds=time.perf_counter() - run_start,
+                    )
+                )
+                logger.info(
+                    "Completed held-out run dataset='%s' entity_type=%s method=%s mrr=%.4f runtime=%.4fs",
+                    dataset_name,
+                    entity_type.value,
+                    method_name,
+                    mrr,
+                    results[-1]["runtime_seconds"],
+                )
+        logger.info("Finished held-out dataset '%s'", dataset_name)
+
+    _persist_results_to_csv(
+        results,
+        output_csv_path=resolved_output_csv_path,
+        evaluation_ks=evaluation_ks,
+    )
+    logger.info(
+        "Persisted %d held-out KG result record(s) to %s",
+        len(results),
+        resolved_output_csv_path,
+    )
+    logger.info("Held-out KG run finished with %d result record(s)", len(results))
+    return results

--- a/src/main.py
+++ b/src/main.py
@@ -51,6 +51,25 @@ def generate_depth_analysis(*, results_csv_path: str | Path | None, output_dir: 
     return _impl(results_csv_path=results_csv_path, output_dir=output_dir)
 
 
+def run_heldout_kg_experiments(
+    *,
+    config_path: str | Path,
+    selected_settings_path: str | Path | None,
+    output_csv_path: str | Path | None,
+    show_progress: bool | None,
+) -> list[dict[str, object]]:
+    from src.experiments.heldout_kg_runner import (
+        run_heldout_kg_experiments as _impl,
+    )
+
+    return _impl(
+        config_path=config_path,
+        selected_settings_path=selected_settings_path,
+        output_csv_path=output_csv_path,
+        show_progress=show_progress,
+    )
+
+
 def _build_run_parser(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--config-path",
@@ -173,6 +192,41 @@ def _build_depth_analysis_parser(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _build_run_heldout_kg_parser(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--config-path",
+        default="config/runtime.yaml",
+        help="Path to runtime YAML config (default: config/runtime.yaml).",
+    )
+    parser.add_argument(
+        "--selected-settings-json",
+        default=None,
+        help=(
+            "Path to heldout_selected_settings.json. If omitted, the latest "
+            "results/comparisons/**/heldout_selected_settings.json is used."
+        ),
+    )
+    parser.add_argument(
+        "--output-csv-path",
+        default=None,
+        help=(
+            "Output CSV path. If omitted, a heldout run-stamped file is created in results/ "
+            "(heldout_result_YYYYMMDD_HHMMSS_<gitsha>.csv)."
+        ),
+    )
+    progress_group = parser.add_mutually_exclusive_group()
+    progress_group.add_argument(
+        "--progress",
+        action="store_true",
+        help="Force-enable progress bars.",
+    )
+    progress_group.add_argument(
+        "--no-progress",
+        action="store_true",
+        help="Force-disable progress bars.",
+    )
+
+
 def _build_full_run_parser(parser: argparse.ArgumentParser) -> None:
     _build_run_parser(parser)
     parser.add_argument(
@@ -221,6 +275,12 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     _build_depth_analysis_parser(depth_analysis_parser)
 
+    heldout_run_parser = subparsers.add_parser(
+        "run-heldout-kg",
+        help="Run frozen held-out KG evaluation by entity type.",
+    )
+    _build_run_heldout_kg_parser(heldout_run_parser)
+
     full_run_parser = subparsers.add_parser(
         "full-run",
         help="Run experiments and generate all analysis reports in one command.",
@@ -244,6 +304,30 @@ def _resolve_new_result_file(
     if not new_files:
         raise FileNotFoundError(
             "No new results file was created in 'results/' for this run."
+        )
+    return new_files[-1]
+
+
+def _collect_existing_heldout_result_files(
+    results_dir: Path = Path("results"),
+) -> set[Path]:
+    if not results_dir.exists():
+        return set()
+    return {
+        path.resolve() for path in results_dir.glob("heldout_result_*.csv")
+    }
+
+
+def _resolve_new_heldout_result_file(
+    existing_files: set[Path], results_dir: Path = Path("results")
+) -> Path:
+    current_files = {
+        path.resolve() for path in results_dir.glob("heldout_result_*.csv")
+    }
+    new_files = sorted(current_files - existing_files, key=lambda p: p.stat().st_mtime)
+    if not new_files:
+        raise FileNotFoundError(
+            "No new heldout_result_*.csv file was created in 'results/' for this run."
         )
     return new_files[-1]
 
@@ -333,6 +417,32 @@ def _run_depth_analysis_cli(args: argparse.Namespace) -> int:
         output_dir=args.output_dir,
     )
     print(f"Depth Analysis Dir: {artifacts['output_dir']}")
+    return 0
+
+
+def _run_heldout_kg_cli(args: argparse.Namespace) -> int:
+    show_progress = _resolve_show_progress(args)
+    existing_files = (
+        _collect_existing_heldout_result_files()
+        if args.output_csv_path is None
+        else set()
+    )
+    run_heldout_kg_experiments(
+        config_path=args.config_path,
+        selected_settings_path=args.selected_settings_json,
+        output_csv_path=args.output_csv_path,
+        show_progress=show_progress,
+    )
+    final_output_path = (
+        Path(args.output_csv_path)
+        if args.output_csv_path
+        else _resolve_new_heldout_result_file(existing_files)
+    )
+    if not final_output_path.exists():
+        raise FileNotFoundError(
+            f"Expected held-out output CSV was not created: {final_output_path}"
+        )
+    print(f"Held-Out KG Results CSV: {final_output_path}")
     return 0
 
 
@@ -498,6 +608,8 @@ def main(argv: list[str] | None = None) -> int:
             return _run_heldout_selection_cli(args)
         if args.command == "depth-analysis":
             return _run_depth_analysis_cli(args)
+        if args.command == "run-heldout-kg":
+            return _run_heldout_kg_cli(args)
         if args.command == "full-run":
             return _run_full_run_cli(args)
         return _run_experiment_cli(args)

--- a/tests/test_heldout_kg_runner.py
+++ b/tests/test_heldout_kg_runner.py
@@ -1,0 +1,439 @@
+import csv
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.experiments.heldout_kg_runner import (
+    HeldoutKgRunnerValidationError,
+    run_heldout_kg_experiments,
+)
+
+
+def _heldout_source_rdf() -> str:
+    return """<?xml version="1.0"?>
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+  xmlns:owl="http://www.w3.org/2002/07/owl#">
+  <owl:Class rdf:about="http://dbkwik.webdatacommons.org/source/class/Hero">
+    <rdfs:label>Hero</rdfs:label>
+  </owl:Class>
+  <owl:Class rdf:about="http://dbkwik.webdatacommons.org/source/class/Villain">
+    <rdfs:label>Villain</rdfs:label>
+  </owl:Class>
+  <rdf:Description rdf:about="http://dbkwik.webdatacommons.org/source/resource/Thor">
+    <rdfs:label>Thor</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dbkwik.webdatacommons.org/source/resource/Loki">
+    <rdfs:label>Loki</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dbkwik.webdatacommons.org/source/resource/Asgard">
+    <rdfs:label>Asgard</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dbkwik.webdatacommons.org/source/resource/Mjolnir">
+    <rdfs:label>Mjolnir</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dbkwik.webdatacommons.org/source/resource/Film">
+    <rdfs:label>Film</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dbkwik.webdatacommons.org/source/resource/Asgard">
+    <ns1:memberOf xmlns:ns1="http://dbkwik.webdatacommons.org/source/property/" rdf:resource="http://dbkwik.webdatacommons.org/source/resource/Heroes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dbkwik.webdatacommons.org/source/resource/Thor">
+    <ns1:appearsIn xmlns:ns1="http://dbkwik.webdatacommons.org/source/property/" rdf:resource="http://dbkwik.webdatacommons.org/source/resource/Film"/>
+  </rdf:Description>
+</rdf:RDF>
+"""
+
+
+def _heldout_target_rdf() -> str:
+    return """<?xml version="1.0"?>
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+  xmlns:owl="http://www.w3.org/2002/07/owl#">
+  <owl:Class rdf:about="http://dbkwik.webdatacommons.org/target/class/Hero">
+    <rdfs:label>Hero</rdfs:label>
+  </owl:Class>
+  <owl:Class rdf:about="http://dbkwik.webdatacommons.org/target/class/Villain">
+    <rdfs:label>Villain</rdfs:label>
+  </owl:Class>
+  <owl:Class rdf:about="http://dbkwik.webdatacommons.org/target/class/Location">
+    <rdfs:label>Location</rdfs:label>
+  </owl:Class>
+  <rdf:Description rdf:about="http://dbkwik.webdatacommons.org/target/resource/Thor">
+    <rdfs:label>Thor</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dbkwik.webdatacommons.org/target/resource/Loki">
+    <rdfs:label>Loki</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dbkwik.webdatacommons.org/target/resource/Film">
+    <rdfs:label>Film</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dbkwik.webdatacommons.org/target/resource/Mjolnir">
+    <rdfs:label>Mjolnir</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dbkwik.webdatacommons.org/target/resource/Asgard">
+    <rdfs:label>Asgard</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dbkwik.webdatacommons.org/target/resource/Thor">
+    <ns1:appearsIn xmlns:ns1="http://dbkwik.webdatacommons.org/target/property/" rdf:resource="http://dbkwik.webdatacommons.org/target/resource/Film"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dbkwik.webdatacommons.org/target/resource/Asgard">
+    <ns1:memberOf xmlns:ns1="http://dbkwik.webdatacommons.org/target/property/" rdf:resource="http://dbkwik.webdatacommons.org/target/resource/Heroes"/>
+  </rdf:Description>
+</rdf:RDF>
+"""
+
+
+def _heldout_alignment_rdf(*, include_predicate: bool = True) -> str:
+    predicate_map = """
+    <map>
+      <Cell>
+        <entity1 rdf:resource="http://dbkwik.webdatacommons.org/source/property/appearsIn"/>
+        <entity2 rdf:resource="http://dbkwik.webdatacommons.org/target/property/appearsIn"/>
+        <relation>=</relation>
+        <measure>1.0</measure>
+      </Cell>
+    </map>""" if include_predicate else ""
+    return f"""<?xml version="1.0"?>
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns="http://knowledgeweb.semanticweb.org/heterogeneity/alignment#">
+  <Alignment>
+    <map>
+      <Cell>
+        <entity1 rdf:resource="http://dbkwik.webdatacommons.org/source/class/Hero"/>
+        <entity2 rdf:resource="http://dbkwik.webdatacommons.org/target/class/Hero"/>
+        <relation>=</relation>
+        <measure>1.0</measure>
+      </Cell>
+    </map>
+    {predicate_map}
+    <map>
+      <Cell>
+        <entity1 rdf:resource="http://dbkwik.webdatacommons.org/source/resource/Thor"/>
+        <entity2 rdf:resource="http://dbkwik.webdatacommons.org/target/resource/Thor"/>
+        <relation>=</relation>
+        <measure>1.0</measure>
+      </Cell>
+    </map>
+  </Alignment>
+</rdf:RDF>
+"""
+
+
+class HeldoutKgRunnerTests(unittest.TestCase):
+    def _write_config(
+        self,
+        tmp: Path,
+        *,
+        target_rdf_text: str | None = None,
+        alignment_rdf_text: str | None = None,
+    ) -> Path:
+        source = tmp / "source.rdf"
+        target = tmp / "target.rdf"
+        alignment = tmp / "alignment.rdf"
+        source.write_text(_heldout_source_rdf(), encoding="utf-8")
+        target.write_text(target_rdf_text or _heldout_target_rdf(), encoding="utf-8")
+        alignment.write_text(
+            alignment_rdf_text or _heldout_alignment_rdf(),
+            encoding="utf-8",
+        )
+
+        config_path = tmp / "runtime.yaml"
+        config_path.write_text(
+            "\n".join(
+                [
+                    "experiments:",
+                    "  evaluation_ks: [1, 2]",
+                    "  tfidf_grid:",
+                    "    - ngram_range: [2, 2]",
+                    "      min_df: 3",
+                    "      max_df: 0.9",
+                    "      sublinear_tf: true",
+                    "  bm25_grid:",
+                    "    - k1: 0.1",
+                    "      b: 0.1",
+                    "development_datasets:",
+                    "  dev_fixture:",
+                    "    track: conference",
+                    '    version: "v1"',
+                    f"    source_rdf: {source}",
+                    f"    target_rdf: {target}",
+                    f"    alignment_rdf: {alignment}",
+                    "heldout_datasets:",
+                    "  kg_fixture:",
+                    "    track: kg",
+                    '    version: "heldout-v1"',
+                    f"    source_rdf: {source}",
+                    f"    target_rdf: {target}",
+                    f"    alignment_rdf: {alignment}",
+                    "heldout:",
+                    "  selection:",
+                    "    metric: mrr",
+                    "    lambda: 0.5",
+                    "    weighting: equal_track_weight",
+                    "    ranking: per_track_normalized_rank",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return config_path
+
+    def _write_selected_settings(
+        self,
+        path: Path,
+        *,
+        include_bm25: bool = True,
+    ) -> None:
+        selected_settings = {
+            "tfidf": {
+                "method": "tfidf",
+                "hyperparameters": {
+                    "ngram_range": [1, 1],
+                    "min_df": 1,
+                    "max_df": 1.0,
+                    "sublinear_tf": False,
+                },
+            }
+        }
+        if include_bm25:
+            selected_settings["bm25"] = {
+                "method": "bm25",
+                "hyperparameters": {
+                    "k1": 1.8,
+                    "b": 0.75,
+                },
+            }
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "selected_settings": selected_settings,
+                    "heldout_datasets": ["kg_fixture"],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    def test_runner_generates_per_type_rows_and_expected_csv_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config = self._write_config(tmp)
+            selected = tmp / "comparisons" / "result_fixture" / "heldout_selected_settings.json"
+            output_csv = tmp / "results" / "heldout.csv"
+            self._write_selected_settings(selected)
+
+            results = run_heldout_kg_experiments(
+                config_path=config,
+                selected_settings_path=selected,
+                output_csv_path=output_csv,
+                show_progress=False,
+            )
+
+            self.assertEqual(len(results), 6)
+            self.assertTrue(output_csv.exists())
+            with output_csv.open("r", encoding="utf-8", newline="") as csv_file:
+                reader = csv.DictReader(csv_file)
+                self.assertEqual(
+                    reader.fieldnames,
+                    [
+                        "track",
+                        "version",
+                        "dataset",
+                        "entity_type",
+                        "method",
+                        "hyperparameters",
+                        "gold_count",
+                        "target_pool_size",
+                        "retained_candidate_size",
+                        "candidate_reduction_ratio",
+                        "recall_at_1",
+                        "recall_at_2",
+                        "mrr",
+                        "runtime_seconds",
+                    ],
+                )
+                rows = list(reader)
+
+        self.assertEqual(len(rows), 6)
+        entity_types = {row["entity_type"] for row in rows}
+        methods = {row["method"] for row in rows}
+        self.assertEqual(entity_types, {"class", "predicate", "instance"})
+        self.assertEqual(methods, {"tfidf", "bm25"})
+
+    def test_runner_uses_frozen_settings_not_grid_search(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config = self._write_config(tmp)
+            selected = tmp / "heldout_selected_settings.json"
+            self._write_selected_settings(selected)
+
+            results = run_heldout_kg_experiments(
+                config_path=config,
+                selected_settings_path=selected,
+                show_progress=False,
+            )
+
+        self.assertEqual(len(results), 6)
+        for row in results:
+            if row["model"] == "tfidf":
+                self.assertEqual(
+                    row["hyperparameters"],
+                    {
+                        "ngram_range": [1, 1],
+                        "min_df": 1,
+                        "max_df": 1.0,
+                        "sublinear_tf": False,
+                    },
+                )
+            else:
+                self.assertEqual(row["hyperparameters"], {"k1": 1.8, "b": 0.75})
+
+    def test_candidate_reduction_ratio_handles_target_pool_smaller_than_kmax(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config = self._write_config(tmp)
+            selected = tmp / "heldout_selected_settings.json"
+            self._write_selected_settings(selected)
+
+            results = run_heldout_kg_experiments(
+                config_path=config,
+                selected_settings_path=selected,
+                show_progress=False,
+            )
+
+        predicate_row = next(
+            row
+            for row in results
+            if row["entity_type"] == "predicate" and row["model"] == "tfidf"
+        )
+        class_row = next(
+            row
+            for row in results
+            if row["entity_type"] == "class" and row["model"] == "tfidf"
+        )
+        self.assertEqual(predicate_row["target_pool_size"], 2)
+        self.assertEqual(predicate_row["retained_candidate_size"], 2)
+        self.assertAlmostEqual(predicate_row["candidate_reduction_ratio"], 0.0)
+        self.assertEqual(class_row["target_pool_size"], 3)
+        self.assertEqual(class_row["retained_candidate_size"], 2)
+        self.assertAlmostEqual(class_row["candidate_reduction_ratio"], 1.0 - (2.0 / 3.0))
+
+    def test_missing_selected_method_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config = self._write_config(tmp)
+            selected = tmp / "heldout_selected_settings.json"
+            self._write_selected_settings(selected, include_bm25=False)
+
+            with self.assertRaisesRegex(
+                HeldoutKgRunnerValidationError,
+                "missing required method 'bm25'",
+            ):
+                run_heldout_kg_experiments(
+                    config_path=config,
+                    selected_settings_path=selected,
+                    show_progress=False,
+                )
+
+    def test_malformed_selected_hyperparameters_raise_clear_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config = self._write_config(tmp)
+            selected = tmp / "heldout_selected_settings.json"
+            self._write_selected_settings(selected)
+
+            payload = json.loads(selected.read_text(encoding="utf-8"))
+            del payload["selected_settings"]["tfidf"]["hyperparameters"]["min_df"]
+            selected.write_text(
+                json.dumps(payload, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                HeldoutKgRunnerValidationError,
+                "missing required hyperparameter keys: min_df",
+            ):
+                run_heldout_kg_experiments(
+                    config_path=config,
+                    selected_settings_path=selected,
+                    show_progress=False,
+                )
+
+    def test_zero_target_entities_for_required_type_raises(self) -> None:
+        target_without_predicates = _heldout_target_rdf().replace(
+            """  <rdf:Description rdf:about="http://dbkwik.webdatacommons.org/target/resource/Thor">
+    <ns1:appearsIn xmlns:ns1="http://dbkwik.webdatacommons.org/target/property/" rdf:resource="http://dbkwik.webdatacommons.org/target/resource/Film"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dbkwik.webdatacommons.org/target/resource/Asgard">
+    <ns1:memberOf xmlns:ns1="http://dbkwik.webdatacommons.org/target/property/" rdf:resource="http://dbkwik.webdatacommons.org/target/resource/Heroes"/>
+  </rdf:Description>
+""",
+            "",
+            1,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config = self._write_config(tmp, target_rdf_text=target_without_predicates)
+            selected = tmp / "heldout_selected_settings.json"
+            self._write_selected_settings(selected)
+
+            with self.assertRaisesRegex(
+                HeldoutKgRunnerValidationError,
+                "zero target entities for entity type 'predicate'",
+            ):
+                run_heldout_kg_experiments(
+                    config_path=config,
+                    selected_settings_path=selected,
+                    show_progress=False,
+                )
+
+    def test_zero_gold_for_required_type_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config = self._write_config(
+                tmp,
+                alignment_rdf_text=_heldout_alignment_rdf(include_predicate=False),
+            )
+            selected = tmp / "heldout_selected_settings.json"
+            self._write_selected_settings(selected)
+
+            with self.assertRaisesRegex(
+                HeldoutKgRunnerValidationError,
+                "zero gold mappings for entity type 'predicate'",
+            ):
+                run_heldout_kg_experiments(
+                    config_path=config,
+                    selected_settings_path=selected,
+                    show_progress=False,
+                )
+
+    def test_runner_uses_latest_selected_settings_when_omitted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config = self._write_config(tmp)
+            results_root = tmp / "results" / "comparisons" / "result_fixture"
+            selected = results_root / "heldout_selected_settings.json"
+            self._write_selected_settings(selected)
+            output_csv = tmp / "results" / "heldout.csv"
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(tmp)
+                results = run_heldout_kg_experiments(
+                    config_path=config.name,
+                    selected_settings_path=None,
+                    output_csv_path=output_csv,
+                    show_progress=False,
+                )
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertEqual(len(results), 6)

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -439,6 +439,79 @@ heldout:
         self.assertIn("Error: ValueError: bad heldout input", stderr.getvalue())
         self.assertIn("CLI execution failed", "\n".join(captured.output))
 
+    def test_run_heldout_kg_explicit_args(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            output_csv = tmp / "heldout.csv"
+            stdout = io.StringIO()
+
+            with patch("src.main.run_heldout_kg_experiments", return_value=[]) as heldout_mock:
+                output_csv.write_text("track,version\n", encoding="utf-8")
+                with contextlib.redirect_stdout(stdout):
+                    exit_code = main(
+                        [
+                            "run-heldout-kg",
+                            "--config-path",
+                            str(tmp / "runtime.yaml"),
+                            "--selected-settings-json",
+                            str(tmp / "heldout_selected_settings.json"),
+                            "--output-csv-path",
+                            str(output_csv),
+                        ]
+                    )
+
+            self.assertEqual(exit_code, 0)
+            heldout_mock.assert_called_once_with(
+                config_path=str(tmp / "runtime.yaml"),
+                selected_settings_path=str(tmp / "heldout_selected_settings.json"),
+                output_csv_path=str(output_csv),
+                show_progress=None,
+            )
+            self.assertIn(f"Held-Out KG Results CSV: {output_csv}", stdout.getvalue())
+
+    def test_run_heldout_kg_default_selected_settings_and_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            stdout = io.StringIO()
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(tmp)
+                with patch("src.main.run_heldout_kg_experiments", return_value=[]) as heldout_mock:
+                    expected_output = tmp / "results" / "heldout_result_20260101_000000_deadbeef.csv"
+                    expected_output.parent.mkdir(parents=True, exist_ok=True)
+                    expected_output.write_text("track,version\n", encoding="utf-8")
+                    with patch(
+                        "src.main._resolve_new_heldout_result_file",
+                        return_value=expected_output,
+                    ):
+                        with contextlib.redirect_stdout(stdout):
+                            exit_code = main(["run-heldout-kg"])
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertEqual(exit_code, 0)
+        heldout_mock.assert_called_once_with(
+            config_path="config/runtime.yaml",
+            selected_settings_path=None,
+            output_csv_path=None,
+            show_progress=None,
+        )
+        self.assertIn("Held-Out KG Results CSV:", stdout.getvalue())
+
+    def test_run_heldout_kg_failure_path(self) -> None:
+        stderr = io.StringIO()
+        with self.assertLogs("src.main", level="ERROR") as captured:
+            with patch(
+                "src.main.run_heldout_kg_experiments",
+                side_effect=ValueError("bad heldout kg input"),
+            ):
+                with contextlib.redirect_stderr(stderr):
+                    exit_code = main(["run-heldout-kg"])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("Error: ValueError: bad heldout kg input", stderr.getvalue())
+        self.assertIn("CLI execution failed", "\n".join(captured.output))
+
     def test_depth_analysis_explicit_args(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
@@ -705,6 +778,7 @@ heldout:
         self.assertIn("depth-analysis", help_text)
         self.assertIn("bm25-sensitivity", help_text)
         self.assertIn("select-heldout-settings", help_text)
+        self.assertIn("run-heldout-kg", help_text)
         self.assertIn("full-run", help_text)
         self.assertIn("run", help_text)
 


### PR DESCRIPTION
## Summary
- add a dedicated held-out KG runner that uses frozen TF-IDF and BM25 settings by entity type
- evaluate classes, predicates, and instances separately and write held-out CSV output with candidate reduction ratio
- add CLI coverage and held-out runner tests, including malformed selected-settings validation

## Testing
- ./venv/bin/python3.12 -m unittest tests.test_heldout_kg_runner tests.test_main_cli -v
- ./venv/bin/python3.12 -m unittest tests.test_entity_partitioning tests.test_heldout_kg_runner tests.test_experiment_runner tests.test_main_cli -v

Closes #35
