### PR TITLE
feat: add held-out KG reporting artifacts (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,33 @@ The held-out KG results CSV includes:
 - fixed `recall_at_<k>` columns
 - `mrr`
 
+## Held-Out KG Reporting
+
+Use the held-out KG reporting command to summarize frozen TF-IDF and BM25 results by
+entity type and generate macro/micro summaries.
+
+With latest held-out results CSV and latest selected-settings artifact (auto-detected when
+available):
+
+```bash
+python -m src.main report-heldout-kg
+```
+
+With explicit held-out results CSV and selected-settings artifact:
+
+```bash
+python -m src.main report-heldout-kg --results-csv results/heldout_result_YYYYMMDD_HHMMSS_<gitsha>.csv --selected-settings-json results/comparisons/result_YYYYMMDD_HHMMSS_<gitsha>/heldout_selected_settings.json --output-dir results/comparisons
+```
+
+Generated files:
+
+- `kg_heldout_by_type_summary.csv`
+- `kg_heldout_macro_summary.csv`
+- `kg_heldout_micro_summary.csv`
+- `kg_heldout_reduction_effectiveness.csv`
+- `kg_heldout_interpretation_scaffold.md`
+- `kg_heldout_transfer_summary.csv` when a compatible selected-settings artifact is available
+
 ## Logging
 
 Experiment logs are written to timestamped files under `logs/`:

--- a/src/analysis/kg_heldout_reporting.py
+++ b/src/analysis/kg_heldout_reporting.py
@@ -1,0 +1,646 @@
+"""Reporting utilities for held-out KG evaluation artifacts."""
+
+from __future__ import annotations
+
+import csv
+from datetime import datetime
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+REQUIRED_COLUMNS = {
+    "track",
+    "version",
+    "dataset",
+    "entity_type",
+    "method",
+    "hyperparameters",
+    "gold_count",
+    "target_pool_size",
+    "retained_candidate_size",
+    "candidate_reduction_ratio",
+    "mrr",
+    "runtime_seconds",
+}
+REQUIRED_METHODS = {"tfidf", "bm25"}
+REQUIRED_ENTITY_TYPES = {"class", "predicate", "instance"}
+
+
+class KgHeldoutReportingValidationError(ValueError):
+    """Raised when held-out reporting inputs are invalid."""
+
+
+def _resolve_results_csv(results_csv_path: str | Path | None) -> Path:
+    if results_csv_path is not None:
+        path = Path(results_csv_path).resolve()
+        if not path.exists():
+            raise FileNotFoundError(f"Held-out KG results CSV not found: {path}")
+        return path
+
+    candidates = sorted(
+        Path("results").glob("heldout_result_*.csv"),
+        key=lambda candidate: candidate.stat().st_mtime,
+    )
+    if not candidates:
+        raise FileNotFoundError("No results/heldout_result_*.csv files found for reporting.")
+    return candidates[-1].resolve()
+
+
+def _resolve_selected_settings_json(
+    selected_settings_path: str | Path | None,
+    *,
+    heldout_datasets: set[str],
+) -> tuple[Path | None, bool]:
+    if selected_settings_path is not None:
+        path = Path(selected_settings_path).resolve()
+        if not path.exists():
+            raise FileNotFoundError(f"Selected settings JSON not found: {path}")
+        return path, True
+
+    candidates = sorted(
+        Path("results/comparisons").glob("**/heldout_selected_settings.json"),
+        key=lambda candidate: candidate.stat().st_mtime,
+    )
+    if not candidates:
+        return None, False
+
+    matching_candidates: list[Path] = []
+    for candidate in candidates:
+        try:
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        candidate_datasets = payload.get("heldout_datasets")
+        if not isinstance(candidate_datasets, list):
+            continue
+        candidate_dataset_set = {str(value) for value in candidate_datasets}
+        if candidate_dataset_set == heldout_datasets:
+            matching_candidates.append(candidate.resolve())
+
+    if len(matching_candidates) == 1:
+        return matching_candidates[0], False
+
+    if len(matching_candidates) > 1:
+        logger.warning(
+            "Skipping transfer summary because multiple selected-settings artifacts match held-out datasets: %s",
+            matching_candidates,
+        )
+        return None, False
+
+    logger.warning(
+        "Skipping transfer summary because no selected-settings artifact matches held-out datasets: %s",
+        sorted(heldout_datasets),
+    )
+    return None, False
+
+
+def _find_recall_columns(frame: pd.DataFrame) -> list[str]:
+    recall_columns = [column for column in frame.columns if column.startswith("recall_at_")]
+    if not recall_columns:
+        raise KgHeldoutReportingValidationError(
+            "Held-out KG reporting requires at least one recall_at_<k> column."
+        )
+    return sorted(recall_columns, key=lambda column: int(column.removeprefix("recall_at_")))
+
+
+def _validate_results_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, list[str]]:
+    missing_columns = sorted(REQUIRED_COLUMNS - set(frame.columns))
+    if missing_columns:
+        raise KgHeldoutReportingValidationError(
+            "Missing required held-out reporting column(s): " + ", ".join(missing_columns)
+        )
+
+    validated = frame.copy()
+    validated["track"] = validated["track"].astype(str)
+    validated["version"] = validated["version"].astype(str)
+    validated["dataset"] = validated["dataset"].astype(str)
+    validated["entity_type"] = validated["entity_type"].astype(str)
+    validated["method"] = validated["method"].astype(str)
+    validated["hyperparameters"] = validated["hyperparameters"].astype(str)
+
+    numeric_columns = [
+        "gold_count",
+        "target_pool_size",
+        "retained_candidate_size",
+        "candidate_reduction_ratio",
+        "mrr",
+        "runtime_seconds",
+    ]
+    for column in numeric_columns:
+        validated[column] = validated[column].astype(float)
+
+    recall_columns = _find_recall_columns(validated)
+    for column in recall_columns:
+        validated[column] = validated[column].astype(float)
+
+    methods = set(validated["method"].unique())
+    if methods != REQUIRED_METHODS:
+        raise KgHeldoutReportingValidationError(
+            "Held-out KG reporting requires exactly these methods: "
+            + ", ".join(sorted(REQUIRED_METHODS))
+        )
+
+    entity_types = set(validated["entity_type"].unique())
+    if entity_types != REQUIRED_ENTITY_TYPES:
+        raise KgHeldoutReportingValidationError(
+            "Held-out KG reporting requires exactly these entity types: "
+            + ", ".join(sorted(REQUIRED_ENTITY_TYPES))
+        )
+
+    coverage = (
+        validated.groupby(["track", "version", "dataset", "entity_type"])["method"]
+        .nunique()
+        .reset_index(name="method_count")
+    )
+    incomplete = coverage[coverage["method_count"] != len(REQUIRED_METHODS)]
+    if not incomplete.empty:
+        bad = incomplete.iloc[0]
+        raise KgHeldoutReportingValidationError(
+            "Each dataset/entity_type pair must have one TF-IDF row and one BM25 row. "
+            f"Found incomplete coverage for dataset='{bad['dataset']}', entity_type='{bad['entity_type']}'."
+        )
+
+    duplicates = (
+        validated.groupby(["track", "version", "dataset", "entity_type", "method"])
+        .size()
+        .reset_index(name="row_count")
+    )
+    duplicated_rows = duplicates[duplicates["row_count"] != 1]
+    if not duplicated_rows.empty:
+        bad = duplicated_rows.iloc[0]
+        raise KgHeldoutReportingValidationError(
+            "Held-out reporting requires exactly one row per dataset/entity_type/method. "
+            f"Found {int(bad['row_count'])} row(s) for dataset='{bad['dataset']}', "
+            f"entity_type='{bad['entity_type']}', method='{bad['method']}'."
+        )
+
+    return validated.sort_values(
+        ["track", "dataset", "entity_type", "method"], kind="mergesort"
+    ).reset_index(drop=True), recall_columns
+
+
+def _build_by_type_summary(frame: pd.DataFrame, recall_columns: list[str]) -> pd.DataFrame:
+    aggregation: dict[str, str] = {
+        "dataset": "count",
+        "gold_count": "sum",
+        "target_pool_size": "mean",
+        "retained_candidate_size": "mean",
+        "candidate_reduction_ratio": "mean",
+        "mrr": "mean",
+    }
+    for column in recall_columns:
+        aggregation[column] = "mean"
+
+    summary = (
+        frame.groupby(["entity_type", "method"], as_index=False)
+        .agg(aggregation)
+        .rename(
+            columns={
+                "dataset": "dataset_count",
+                "gold_count": "gold_count_sum",
+                "target_pool_size": "target_pool_size_mean",
+                "retained_candidate_size": "retained_candidate_size_mean",
+                "candidate_reduction_ratio": "candidate_reduction_ratio_mean",
+                "mrr": "mrr_mean",
+                **{column: f"{column}_mean" for column in recall_columns},
+            }
+        )
+    )
+    return summary.sort_values(["entity_type", "method"], kind="mergesort").reset_index(drop=True)
+
+
+def _delta_row(
+    frame: pd.DataFrame,
+    *,
+    value_columns: list[str],
+    method_column: str = "method",
+) -> dict[str, object]:
+    indexed = frame.set_index(method_column)
+    if "tfidf" not in indexed.index or "bm25" not in indexed.index:
+        raise KgHeldoutReportingValidationError("Expected tfidf and bm25 rows for delta computation.")
+
+    row: dict[str, object] = {method_column: "delta_tfidf_minus_bm25"}
+    for column in value_columns:
+        row[column] = float(indexed.loc["tfidf", column] - indexed.loc["bm25", column])
+    return row
+
+
+def _build_macro_summary(by_type_summary: pd.DataFrame, recall_columns: list[str]) -> pd.DataFrame:
+    value_columns = [
+        "dataset_count",
+        "gold_count_sum",
+        "target_pool_size_mean",
+        "retained_candidate_size_mean",
+        "candidate_reduction_ratio_mean",
+        "mrr_mean",
+        *(f"{column}_mean" for column in recall_columns),
+    ]
+    method_rows: list[dict[str, object]] = []
+    for method in sorted(REQUIRED_METHODS):
+        group = by_type_summary[by_type_summary["method"] == method].sort_values(
+            ["entity_type"], kind="mergesort"
+        )
+        row = {"method": method, "type_count": int(len(group))}
+        for column in value_columns:
+            row[column] = float(group[column].mean())
+        method_rows.append(row)
+
+    summary = pd.DataFrame(method_rows)
+    summary = pd.concat(
+        [summary, pd.DataFrame([_delta_row(summary, value_columns=value_columns)])],
+        ignore_index=True,
+    )
+    summary = summary.rename(
+        columns={
+            "dataset_count": "dataset_count_macro_mean",
+            "gold_count_sum": "gold_count_sum_macro_mean",
+        }
+    )
+    return summary.sort_values(["method"], kind="mergesort").reset_index(drop=True)
+
+
+def _weighted_mean(values: pd.Series, weights: pd.Series) -> float:
+    total_weight = float(weights.sum())
+    if total_weight <= 0.0:
+        raise KgHeldoutReportingValidationError("Gold-weighted micro-average requires positive total gold_count.")
+    return float((values * weights).sum() / total_weight)
+
+
+def _build_micro_summary(frame: pd.DataFrame, recall_columns: list[str]) -> pd.DataFrame:
+    method_rows: list[dict[str, object]] = []
+    for method in sorted(REQUIRED_METHODS):
+        group = frame[frame["method"] == method].sort_values(
+            ["track", "dataset", "entity_type"], kind="mergesort"
+        )
+        weights = group["gold_count"]
+        row: dict[str, object] = {
+            "method": method,
+            "dataset_type_row_count": int(len(group)),
+            "gold_count_sum": float(group["gold_count"].sum()),
+            "target_pool_size_sum": float(group["target_pool_size"].sum()),
+            "retained_candidate_size_sum": float(group["retained_candidate_size"].sum()),
+            "candidate_reduction_ratio": _weighted_mean(
+                group["candidate_reduction_ratio"], weights
+            ),
+            "mrr": _weighted_mean(group["mrr"], weights),
+        }
+        for column in recall_columns:
+            row[column] = _weighted_mean(group[column], weights)
+        method_rows.append(row)
+
+    value_columns = [
+        "dataset_type_row_count",
+        "gold_count_sum",
+        "target_pool_size_sum",
+        "retained_candidate_size_sum",
+        "candidate_reduction_ratio",
+        "mrr",
+        *recall_columns,
+    ]
+    summary = pd.DataFrame(method_rows)
+    summary = pd.concat(
+        [summary, pd.DataFrame([_delta_row(summary, value_columns=value_columns)])],
+        ignore_index=True,
+    )
+    return summary.sort_values(["method"], kind="mergesort").reset_index(drop=True)
+
+
+def _build_reduction_effectiveness(frame: pd.DataFrame, recall_columns: list[str]) -> pd.DataFrame:
+    base_columns = [
+        "track",
+        "version",
+        "dataset",
+        "entity_type",
+        "method",
+        "hyperparameters",
+        "gold_count",
+        "target_pool_size",
+        "retained_candidate_size",
+        "candidate_reduction_ratio",
+        *recall_columns,
+        "mrr",
+        "runtime_seconds",
+    ]
+    enriched = frame[base_columns].copy()
+
+    paired = (
+        frame.pivot(
+            index=["track", "version", "dataset", "entity_type"],
+            columns="method",
+            values=["candidate_reduction_ratio", "mrr", *recall_columns],
+        )
+        .sort_index()
+    )
+
+    def paired_value(row: pd.Series, metric: str, method: str) -> float:
+        return float(paired.loc[(row["track"], row["version"], row["dataset"], row["entity_type"]), (metric, method)])
+
+    enriched["other_method"] = enriched["method"].map({"tfidf": "bm25", "bm25": "tfidf"})
+    for metric in ["candidate_reduction_ratio", "mrr", *recall_columns]:
+        delta_column = f"{metric}_delta_vs_other_method"
+        deltas: list[float] = []
+        for row in enriched.itertuples(index=False):
+            current_method = str(row.method)
+            current_value = paired_value(pd.Series(row._asdict()), metric, current_method)
+            other_value = paired_value(
+                pd.Series(row._asdict()),
+                metric,
+                "bm25" if current_method == "tfidf" else "tfidf",
+            )
+            deltas.append(float(current_value - other_value))
+        enriched[delta_column] = deltas
+
+    return enriched.sort_values(
+        ["track", "dataset", "entity_type", "method"], kind="mergesort"
+    ).reset_index(drop=True)
+
+
+def _load_selected_settings_payload(
+    selected_settings_path: Path | None,
+    *,
+    strict: bool,
+) -> tuple[dict[str, dict[str, float]] | None, str | None]:
+    if selected_settings_path is None:
+        return None, "No uniquely matching selected-settings artifact was found; transfer summary skipped."
+
+    try:
+        payload = json.loads(selected_settings_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        if strict:
+            raise KgHeldoutReportingValidationError(
+                f"Malformed selected settings JSON: {selected_settings_path}"
+            ) from exc
+        logger.warning("Skipping transfer summary due to malformed selected settings JSON: %s", selected_settings_path)
+        return None, "Selected-settings artifact was malformed; transfer summary skipped."
+
+    if not isinstance(payload, dict) or not isinstance(payload.get("selected_settings"), dict):
+        if strict:
+            raise KgHeldoutReportingValidationError(
+                f"Selected settings JSON missing 'selected_settings' object: {selected_settings_path}"
+            )
+        logger.warning(
+            "Skipping transfer summary due to invalid selected settings payload: %s",
+            selected_settings_path,
+        )
+        return None, "Selected-settings artifact was invalid; transfer summary skipped."
+
+    selected_settings = payload["selected_settings"]
+    transfer_payload: dict[str, dict[str, float]] = {}
+    try:
+        for method in sorted(REQUIRED_METHODS):
+            entry = selected_settings[method]
+            transfer_payload[method] = {
+                "development_selection_score": float(entry["heldout_score"]),
+                "development_mu": float(entry["mu"]),
+                "development_sigma": float(entry["sigma"]),
+            }
+    except (KeyError, TypeError, ValueError) as exc:
+        if strict:
+            raise KgHeldoutReportingValidationError(
+                f"Selected settings JSON missing transfer summary fields: {selected_settings_path}"
+            ) from exc
+        logger.warning(
+            "Skipping transfer summary due to incomplete selected settings fields: %s",
+            selected_settings_path,
+        )
+        return None, "Selected-settings artifact was incomplete; transfer summary skipped."
+
+    return transfer_payload, None
+
+
+def _build_transfer_summary(
+    transfer_payload: dict[str, dict[str, float]],
+    macro_summary: pd.DataFrame,
+    micro_summary: pd.DataFrame,
+) -> pd.DataFrame:
+    macro_by_method = macro_summary[macro_summary["method"].isin(REQUIRED_METHODS)].set_index("method")
+    micro_by_method = micro_summary[micro_summary["method"].isin(REQUIRED_METHODS)].set_index("method")
+
+    rows: list[dict[str, object]] = []
+    for method in sorted(REQUIRED_METHODS):
+        development = transfer_payload[method]
+        heldout_macro_mrr = float(macro_by_method.loc[method, "mrr_mean"])
+        heldout_micro_mrr = float(micro_by_method.loc[method, "mrr"])
+        development_mu = float(development["development_mu"])
+        rows.append(
+            {
+                "method": method,
+                "development_selection_score": float(development["development_selection_score"]),
+                "development_mu": development_mu,
+                "development_sigma": float(development["development_sigma"]),
+                "heldout_macro_mrr": heldout_macro_mrr,
+                "heldout_micro_mrr": heldout_micro_mrr,
+                "macro_transfer_gap": float(heldout_macro_mrr - development_mu),
+                "micro_transfer_gap": float(heldout_micro_mrr - development_mu),
+            }
+        )
+
+    return pd.DataFrame(rows).sort_values(["method"], kind="mergesort").reset_index(drop=True)
+
+
+def _write_interpretation_scaffold(
+    output_path: Path,
+    *,
+    source_csv: Path,
+    by_type_summary: pd.DataFrame,
+    macro_summary: pd.DataFrame,
+    micro_summary: pd.DataFrame,
+    reduction_effectiveness: pd.DataFrame,
+    primary_recall_column: str,
+    transfer_summary: pd.DataFrame | None,
+    transfer_note: str | None,
+) -> None:
+    winners: list[str] = []
+    for entity_type in sorted(REQUIRED_ENTITY_TYPES):
+        group = by_type_summary[by_type_summary["entity_type"] == entity_type].set_index("method")
+        mrr_tfidf = float(group.loc["tfidf", "mrr_mean"])
+        mrr_bm25 = float(group.loc["bm25", "mrr_mean"])
+        recall_tfidf = float(group.loc["tfidf", f"{primary_recall_column}_mean"])
+        recall_bm25 = float(group.loc["bm25", f"{primary_recall_column}_mean"])
+
+        def _winner(left: float, right: float) -> str:
+            if left == right:
+                return "tie"
+            return "tfidf" if left > right else "bm25"
+
+        winners.append(
+            f"- `{entity_type}`: MRR winner `{_winner(mrr_tfidf, mrr_bm25)}`, "
+            f"{primary_recall_column} winner `{_winner(recall_tfidf, recall_bm25)}`"
+        )
+
+    macro_rows = macro_summary[macro_summary["method"].isin(REQUIRED_METHODS)].set_index("method")
+    micro_rows = micro_summary[micro_summary["method"].isin(REQUIRED_METHODS)].set_index("method")
+    reduction_snapshot = reduction_effectiveness[
+        [
+            "entity_type",
+            "method",
+            "candidate_reduction_ratio",
+            "mrr",
+            primary_recall_column,
+        ]
+    ].copy()
+    reduction_snapshot = reduction_snapshot.sort_values(
+        ["entity_type", "method"], kind="mergesort"
+    ).groupby(["entity_type", "method"], as_index=False).mean(numeric_only=True)
+
+    lines = [
+        "# KG Held-Out Interpretation Scaffold",
+        "",
+        "## Inputs",
+        "",
+        f"- Held-out results CSV: `{source_csv}`",
+        "",
+        "## Coverage",
+        "",
+        "- Entity types covered: `class`, `predicate`, `instance`",
+        "- Methods compared: `tfidf`, `bm25`",
+        "",
+        "## Per-Type Winners",
+        "",
+        *winners,
+        "",
+        "## Macro Summary",
+        "",
+        f"- TF-IDF macro MRR: `{macro_rows.loc['tfidf', 'mrr_mean']:.6f}`",
+        f"- BM25 macro MRR: `{macro_rows.loc['bm25', 'mrr_mean']:.6f}`",
+        "",
+        "## Micro Summary",
+        "",
+        f"- TF-IDF micro MRR: `{micro_rows.loc['tfidf', 'mrr']:.6f}`",
+        f"- BM25 micro MRR: `{micro_rows.loc['bm25', 'mrr']:.6f}`",
+        "",
+        "## Reduction vs Effectiveness Prompts",
+        "",
+        f"- Review `{primary_recall_column}` alongside `candidate_reduction_ratio` for each entity type.",
+        "- Check whether the higher-reduction method also preserves MRR consistency across entity types.",
+        "",
+    ]
+
+    if transfer_summary is not None:
+        lines.extend(
+            [
+                "## Transfer Summary",
+                "",
+            ]
+        )
+        for row in transfer_summary.itertuples(index=False):
+            lines.append(
+                f"- `{row.method}`: development selection score `{row.development_selection_score:.6f}`, "
+                f"held-out macro MRR `{row.heldout_macro_mrr:.6f}`, held-out micro MRR `{row.heldout_micro_mrr:.6f}`"
+            )
+        lines.append("")
+    elif transfer_note is not None:
+        lines.extend(
+            [
+                "## Transfer Summary",
+                "",
+                f"- {transfer_note}",
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            "## Trade-Off Snapshot",
+            "",
+        ]
+    )
+    for row in reduction_snapshot.itertuples(index=False):
+        lines.append(
+            f"- `{row.entity_type}` / `{row.method}`: reduction `{row.candidate_reduction_ratio:.6f}`, "
+            f"MRR `{row.mrr:.6f}`, {primary_recall_column} `{getattr(row, primary_recall_column):.6f}`"
+        )
+
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def generate_kg_heldout_reporting(
+    results_csv_path: str | Path | None,
+    output_dir: str | Path = "results/comparisons",
+    selected_settings_path: str | Path | None = None,
+) -> dict[str, Path]:
+    """Generate held-out KG reporting artifacts."""
+    source_csv = _resolve_results_csv(results_csv_path)
+    frame = pd.read_csv(source_csv)
+    validated, recall_columns = _validate_results_frame(frame)
+    heldout_datasets = set(validated["dataset"].unique())
+
+    by_type_summary = _build_by_type_summary(validated, recall_columns)
+    macro_summary = _build_macro_summary(by_type_summary, recall_columns)
+    micro_summary = _build_micro_summary(validated, recall_columns)
+    reduction_effectiveness = _build_reduction_effectiveness(validated, recall_columns)
+
+    selected_settings_json, selected_settings_explicit = _resolve_selected_settings_json(
+        selected_settings_path,
+        heldout_datasets=heldout_datasets,
+    )
+    transfer_payload, transfer_note = _load_selected_settings_payload(
+        selected_settings_json,
+        strict=selected_settings_explicit,
+    )
+    transfer_summary = (
+        _build_transfer_summary(transfer_payload, macro_summary, micro_summary)
+        if transfer_payload is not None
+        else None
+    )
+
+    run_id = source_csv.stem
+    output_root = Path(output_dir) / run_id
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    by_type_path = output_root / "kg_heldout_by_type_summary.csv"
+    macro_path = output_root / "kg_heldout_macro_summary.csv"
+    micro_path = output_root / "kg_heldout_micro_summary.csv"
+    reduction_path = output_root / "kg_heldout_reduction_effectiveness.csv"
+    interpretation_path = output_root / "kg_heldout_interpretation_scaffold.md"
+    transfer_path = output_root / "kg_heldout_transfer_summary.csv"
+    manifest_path = output_root / "manifest.txt"
+
+    by_type_summary.to_csv(by_type_path, index=False)
+    macro_summary.to_csv(macro_path, index=False)
+    micro_summary.to_csv(micro_path, index=False)
+    reduction_effectiveness.to_csv(reduction_path, index=False, quoting=csv.QUOTE_MINIMAL)
+    if transfer_summary is not None:
+        transfer_summary.to_csv(transfer_path, index=False)
+
+    primary_recall_column = recall_columns[-1]
+    _write_interpretation_scaffold(
+        interpretation_path,
+        source_csv=source_csv,
+        by_type_summary=by_type_summary,
+        macro_summary=macro_summary,
+        micro_summary=micro_summary,
+        reduction_effectiveness=reduction_effectiveness,
+        primary_recall_column=primary_recall_column,
+        transfer_summary=transfer_summary,
+        transfer_note=transfer_note,
+    )
+
+    manifest_lines = [
+        f"generated_at={datetime.now().isoformat(timespec='seconds')}",
+        f"source_csv={source_csv}",
+        f"output_dir={output_root}",
+        f"selected_settings_json={selected_settings_json}" if selected_settings_json is not None else "selected_settings_json=",
+    ]
+    manifest_path.write_text("\n".join(manifest_lines) + "\n", encoding="utf-8")
+
+    artifacts: dict[str, Path] = {
+        "source_csv": source_csv,
+        "output_dir": output_root,
+        "kg_heldout_by_type_summary": by_type_path,
+        "kg_heldout_macro_summary": macro_path,
+        "kg_heldout_micro_summary": micro_path,
+        "kg_heldout_reduction_effectiveness": reduction_path,
+        "kg_heldout_interpretation_scaffold": interpretation_path,
+        "manifest": manifest_path,
+    }
+    if transfer_summary is not None:
+        artifacts["kg_heldout_transfer_summary"] = transfer_path
+    return artifacts

--- a/src/main.py
+++ b/src/main.py
@@ -23,6 +23,21 @@ def generate_heldout_selection(
     return _impl(results_csv_path=results_csv_path, config_path=config_path, output_dir=output_dir)
 
 
+def generate_kg_heldout_reporting(
+    *,
+    results_csv_path: str | Path | None,
+    output_dir: str | Path,
+    selected_settings_path: str | Path | None,
+) -> dict[str, Path]:
+    from src.analysis.kg_heldout_reporting import generate_kg_heldout_reporting as _impl
+
+    return _impl(
+        results_csv_path=results_csv_path,
+        output_dir=output_dir,
+        selected_settings_path=selected_settings_path,
+    )
+
+
 def generate_model_comparison(*, results_csv_path: str | Path | None, output_dir: str | Path) -> dict[str, Path]:
     from src.analysis.model_comparison import generate_model_comparison as _impl
 
@@ -192,6 +207,30 @@ def _build_depth_analysis_parser(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _build_report_heldout_kg_parser(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--results-csv",
+        default=None,
+        help=(
+            "Path to held-out KG results CSV. If omitted, the latest results/heldout_result_*.csv "
+            "is used."
+        ),
+    )
+    parser.add_argument(
+        "--selected-settings-json",
+        default=None,
+        help=(
+            "Path to heldout_selected_settings.json. If omitted, the latest "
+            "results/comparisons/**/heldout_selected_settings.json is used when available."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="results/comparisons",
+        help="Directory where held-out reporting artifacts are written (default: results/comparisons).",
+    )
+
+
 def _build_run_heldout_kg_parser(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--config-path",
@@ -274,6 +313,12 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Generate retrieval-depth behavior artifacts from results CSV.",
     )
     _build_depth_analysis_parser(depth_analysis_parser)
+
+    report_heldout_kg_parser = subparsers.add_parser(
+        "report-heldout-kg",
+        help="Generate held-out KG reporting artifacts by entity type.",
+    )
+    _build_report_heldout_kg_parser(report_heldout_kg_parser)
 
     heldout_run_parser = subparsers.add_parser(
         "run-heldout-kg",
@@ -417,6 +462,16 @@ def _run_depth_analysis_cli(args: argparse.Namespace) -> int:
         output_dir=args.output_dir,
     )
     print(f"Depth Analysis Dir: {artifacts['output_dir']}")
+    return 0
+
+
+def _run_report_heldout_kg_cli(args: argparse.Namespace) -> int:
+    artifacts = generate_kg_heldout_reporting(
+        results_csv_path=args.results_csv,
+        output_dir=args.output_dir,
+        selected_settings_path=args.selected_settings_json,
+    )
+    print(f"Held-Out KG Report Dir: {artifacts['output_dir']}")
     return 0
 
 
@@ -608,6 +663,8 @@ def main(argv: list[str] | None = None) -> int:
             return _run_heldout_selection_cli(args)
         if args.command == "depth-analysis":
             return _run_depth_analysis_cli(args)
+        if args.command == "report-heldout-kg":
+            return _run_report_heldout_kg_cli(args)
         if args.command == "run-heldout-kg":
             return _run_heldout_kg_cli(args)
         if args.command == "full-run":

--- a/tests/test_kg_heldout_reporting.py
+++ b/tests/test_kg_heldout_reporting.py
@@ -1,0 +1,455 @@
+import csv
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.analysis.kg_heldout_reporting import (
+    KgHeldoutReportingValidationError,
+    generate_kg_heldout_reporting,
+)
+
+
+class KgHeldoutReportingTests(unittest.TestCase):
+    def _write_results_csv(self, path: Path) -> None:
+        rows = [
+            {
+                "track": "kg",
+                "version": "heldout-v1",
+                "dataset": "d1",
+                "entity_type": "class",
+                "method": "tfidf",
+                "hyperparameters": '{"cfg":"tfidf"}',
+                "gold_count": 10,
+                "target_pool_size": 100,
+                "retained_candidate_size": 50,
+                "candidate_reduction_ratio": 0.50,
+                "recall_at_1": 0.70,
+                "recall_at_50": 0.95,
+                "mrr": 0.90,
+                "runtime_seconds": 0.10,
+            },
+            {
+                "track": "kg",
+                "version": "heldout-v1",
+                "dataset": "d1",
+                "entity_type": "class",
+                "method": "bm25",
+                "hyperparameters": '{"cfg":"bm25"}',
+                "gold_count": 10,
+                "target_pool_size": 100,
+                "retained_candidate_size": 50,
+                "candidate_reduction_ratio": 0.50,
+                "recall_at_1": 0.60,
+                "recall_at_50": 0.90,
+                "mrr": 0.80,
+                "runtime_seconds": 0.05,
+            },
+            {
+                "track": "kg",
+                "version": "heldout-v1",
+                "dataset": "d2",
+                "entity_type": "class",
+                "method": "tfidf",
+                "hyperparameters": '{"cfg":"tfidf"}',
+                "gold_count": 1,
+                "target_pool_size": 80,
+                "retained_candidate_size": 40,
+                "candidate_reduction_ratio": 0.50,
+                "recall_at_1": 0.50,
+                "recall_at_50": 0.80,
+                "mrr": 0.70,
+                "runtime_seconds": 0.11,
+            },
+            {
+                "track": "kg",
+                "version": "heldout-v1",
+                "dataset": "d2",
+                "entity_type": "class",
+                "method": "bm25",
+                "hyperparameters": '{"cfg":"bm25"}',
+                "gold_count": 1,
+                "target_pool_size": 80,
+                "retained_candidate_size": 40,
+                "candidate_reduction_ratio": 0.50,
+                "recall_at_1": 0.40,
+                "recall_at_50": 0.70,
+                "mrr": 0.60,
+                "runtime_seconds": 0.06,
+            },
+            {
+                "track": "kg",
+                "version": "heldout-v1",
+                "dataset": "d1",
+                "entity_type": "predicate",
+                "method": "tfidf",
+                "hyperparameters": '{"cfg":"tfidf"}',
+                "gold_count": 1,
+                "target_pool_size": 20,
+                "retained_candidate_size": 5,
+                "candidate_reduction_ratio": 0.75,
+                "recall_at_1": 0.20,
+                "recall_at_50": 0.50,
+                "mrr": 0.40,
+                "runtime_seconds": 0.07,
+            },
+            {
+                "track": "kg",
+                "version": "heldout-v1",
+                "dataset": "d1",
+                "entity_type": "predicate",
+                "method": "bm25",
+                "hyperparameters": '{"cfg":"bm25"}',
+                "gold_count": 1,
+                "target_pool_size": 20,
+                "retained_candidate_size": 5,
+                "candidate_reduction_ratio": 0.75,
+                "recall_at_1": 0.30,
+                "recall_at_50": 0.55,
+                "mrr": 0.50,
+                "runtime_seconds": 0.04,
+            },
+            {
+                "track": "kg",
+                "version": "heldout-v1",
+                "dataset": "d2",
+                "entity_type": "predicate",
+                "method": "tfidf",
+                "hyperparameters": '{"cfg":"tfidf"}',
+                "gold_count": 1,
+                "target_pool_size": 10,
+                "retained_candidate_size": 4,
+                "candidate_reduction_ratio": 0.60,
+                "recall_at_1": 0.30,
+                "recall_at_50": 0.70,
+                "mrr": 0.60,
+                "runtime_seconds": 0.08,
+            },
+            {
+                "track": "kg",
+                "version": "heldout-v1",
+                "dataset": "d2",
+                "entity_type": "predicate",
+                "method": "bm25",
+                "hyperparameters": '{"cfg":"bm25"}',
+                "gold_count": 1,
+                "target_pool_size": 10,
+                "retained_candidate_size": 4,
+                "candidate_reduction_ratio": 0.60,
+                "recall_at_1": 0.20,
+                "recall_at_50": 0.65,
+                "mrr": 0.55,
+                "runtime_seconds": 0.03,
+            },
+            {
+                "track": "kg",
+                "version": "heldout-v1",
+                "dataset": "d1",
+                "entity_type": "instance",
+                "method": "tfidf",
+                "hyperparameters": '{"cfg":"tfidf"}',
+                "gold_count": 1,
+                "target_pool_size": 200,
+                "retained_candidate_size": 50,
+                "candidate_reduction_ratio": 0.75,
+                "recall_at_1": 0.10,
+                "recall_at_50": 0.40,
+                "mrr": 0.30,
+                "runtime_seconds": 0.12,
+            },
+            {
+                "track": "kg",
+                "version": "heldout-v1",
+                "dataset": "d1",
+                "entity_type": "instance",
+                "method": "bm25",
+                "hyperparameters": '{"cfg":"bm25"}',
+                "gold_count": 1,
+                "target_pool_size": 200,
+                "retained_candidate_size": 50,
+                "candidate_reduction_ratio": 0.75,
+                "recall_at_1": 0.15,
+                "recall_at_50": 0.35,
+                "mrr": 0.35,
+                "runtime_seconds": 0.09,
+            },
+            {
+                "track": "kg",
+                "version": "heldout-v1",
+                "dataset": "d2",
+                "entity_type": "instance",
+                "method": "tfidf",
+                "hyperparameters": '{"cfg":"tfidf"}',
+                "gold_count": 20,
+                "target_pool_size": 150,
+                "retained_candidate_size": 50,
+                "candidate_reduction_ratio": 2.0 / 3.0,
+                "recall_at_1": 0.40,
+                "recall_at_50": 0.60,
+                "mrr": 0.50,
+                "runtime_seconds": 0.13,
+            },
+            {
+                "track": "kg",
+                "version": "heldout-v1",
+                "dataset": "d2",
+                "entity_type": "instance",
+                "method": "bm25",
+                "hyperparameters": '{"cfg":"bm25"}',
+                "gold_count": 20,
+                "target_pool_size": 150,
+                "retained_candidate_size": 50,
+                "candidate_reduction_ratio": 2.0 / 3.0,
+                "recall_at_1": 0.45,
+                "recall_at_50": 0.65,
+                "mrr": 0.55,
+                "runtime_seconds": 0.10,
+            },
+        ]
+
+        with path.open("w", encoding="utf-8", newline="") as csv_file:
+            writer = csv.DictWriter(csv_file, fieldnames=list(rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(rows)
+
+    def _write_selected_settings(self, path: Path) -> None:
+        payload = {
+            "heldout_datasets": ["d1", "d2"],
+            "selected_settings": {
+                "tfidf": {
+                    "method": "tfidf",
+                    "heldout_score": 0.90,
+                    "mu": 0.88,
+                    "sigma": 0.04,
+                },
+                "bm25": {
+                    "method": "bm25",
+                    "heldout_score": 0.75,
+                    "mu": 0.78,
+                    "sigma": 0.06,
+                },
+            }
+        }
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    def test_generates_expected_artifacts_and_stable_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            results_csv = tmp / "heldout_result_fixture.csv"
+            selected_json = tmp / "comparisons" / "result_fixture" / "heldout_selected_settings.json"
+            self._write_results_csv(results_csv)
+            self._write_selected_settings(selected_json)
+
+            artifacts = generate_kg_heldout_reporting(
+                results_csv_path=results_csv,
+                output_dir=tmp / "comparisons",
+                selected_settings_path=selected_json,
+            )
+            second_artifacts = generate_kg_heldout_reporting(
+                results_csv_path=results_csv,
+                output_dir=tmp / "comparisons_second",
+                selected_settings_path=selected_json,
+            )
+
+            expected_keys = {
+                "source_csv",
+                "output_dir",
+                "kg_heldout_by_type_summary",
+                "kg_heldout_macro_summary",
+                "kg_heldout_micro_summary",
+                "kg_heldout_reduction_effectiveness",
+                "kg_heldout_interpretation_scaffold",
+                "kg_heldout_transfer_summary",
+                "manifest",
+            }
+            self.assertEqual(set(artifacts.keys()), expected_keys)
+
+            stable_keys = expected_keys - {"source_csv", "output_dir", "manifest"}
+            for key in stable_keys:
+                self.assertEqual(
+                    Path(artifacts[key]).read_text(encoding="utf-8"),
+                    Path(second_artifacts[key]).read_text(encoding="utf-8"),
+                )
+
+    def test_grouping_macro_micro_and_transfer_values(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            results_csv = tmp / "heldout_result_fixture.csv"
+            selected_json = tmp / "heldout_selected_settings.json"
+            self._write_results_csv(results_csv)
+            self._write_selected_settings(selected_json)
+
+            artifacts = generate_kg_heldout_reporting(
+                results_csv_path=results_csv,
+                output_dir=tmp / "comparisons",
+                selected_settings_path=selected_json,
+            )
+
+            with Path(artifacts["kg_heldout_by_type_summary"]).open(encoding="utf-8") as csv_file:
+                by_type_rows = list(csv.DictReader(csv_file))
+            self.assertEqual(len(by_type_rows), 6)
+
+            class_tfidf = next(
+                row
+                for row in by_type_rows
+                if row["entity_type"] == "class" and row["method"] == "tfidf"
+            )
+            self.assertEqual(int(class_tfidf["dataset_count"]), 2)
+            self.assertEqual(float(class_tfidf["gold_count_sum"]), 11.0)
+            self.assertAlmostEqual(float(class_tfidf["mrr_mean"]), 0.8)
+            self.assertAlmostEqual(float(class_tfidf["recall_at_50_mean"]), 0.875)
+
+            with Path(artifacts["kg_heldout_macro_summary"]).open(encoding="utf-8") as csv_file:
+                macro_rows = list(csv.DictReader(csv_file))
+            macro_tfidf = next(row for row in macro_rows if row["method"] == "tfidf")
+            macro_bm25 = next(row for row in macro_rows if row["method"] == "bm25")
+            self.assertIn("dataset_count_macro_mean", macro_tfidf)
+            self.assertIn("gold_count_sum_macro_mean", macro_tfidf)
+            self.assertAlmostEqual(float(macro_tfidf["mrr_mean"]), (0.8 + 0.5 + 0.4) / 3.0)
+            self.assertAlmostEqual(float(macro_bm25["mrr_mean"]), (0.7 + 0.525 + 0.45) / 3.0)
+
+            with Path(artifacts["kg_heldout_micro_summary"]).open(encoding="utf-8") as csv_file:
+                micro_rows = list(csv.DictReader(csv_file))
+            micro_tfidf = next(row for row in micro_rows if row["method"] == "tfidf")
+            micro_bm25 = next(row for row in micro_rows if row["method"] == "bm25")
+            self.assertAlmostEqual(float(micro_tfidf["mrr"]), 21.0 / 34.0)
+            self.assertAlmostEqual(float(micro_bm25["mrr"]), 21.0 / 34.0)
+
+            with Path(artifacts["kg_heldout_transfer_summary"]).open(encoding="utf-8") as csv_file:
+                transfer_rows = list(csv.DictReader(csv_file))
+            transfer_tfidf = next(row for row in transfer_rows if row["method"] == "tfidf")
+            self.assertAlmostEqual(float(transfer_tfidf["development_selection_score"]), 0.90)
+            self.assertAlmostEqual(float(transfer_tfidf["development_mu"]), 0.88)
+            self.assertAlmostEqual(float(transfer_tfidf["heldout_macro_mrr"]), (0.8 + 0.5 + 0.4) / 3.0)
+            self.assertAlmostEqual(float(transfer_tfidf["heldout_micro_mrr"]), 21.0 / 34.0)
+
+    def test_reduction_effectiveness_includes_per_pair_deltas(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            results_csv = tmp / "heldout_result_fixture.csv"
+            self._write_results_csv(results_csv)
+
+            artifacts = generate_kg_heldout_reporting(
+                results_csv_path=results_csv,
+                output_dir=tmp / "comparisons",
+            )
+
+            with Path(artifacts["kg_heldout_reduction_effectiveness"]).open(
+                encoding="utf-8"
+            ) as csv_file:
+                rows = list(csv.DictReader(csv_file))
+
+            tfidf_class = next(
+                row
+                for row in rows
+                if row["dataset"] == "d1" and row["entity_type"] == "class" and row["method"] == "tfidf"
+            )
+            self.assertEqual(tfidf_class["other_method"], "bm25")
+            self.assertAlmostEqual(float(tfidf_class["mrr_delta_vs_other_method"]), 0.10)
+            self.assertAlmostEqual(float(tfidf_class["recall_at_50_delta_vs_other_method"]), 0.05)
+            self.assertAlmostEqual(
+                float(tfidf_class["candidate_reduction_ratio_delta_vs_other_method"]), 0.0
+            )
+
+    def test_skips_transfer_summary_when_auto_detection_is_unavailable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            results_csv = tmp / "results" / "heldout_result_fixture.csv"
+            results_csv.parent.mkdir(parents=True, exist_ok=True)
+            self._write_results_csv(results_csv)
+
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(tmp)
+                artifacts = generate_kg_heldout_reporting(
+                    results_csv_path=None,
+                    output_dir=tmp / "comparisons",
+                    selected_settings_path=None,
+                )
+            finally:
+                os.chdir(old_cwd)
+
+            self.assertNotIn("kg_heldout_transfer_summary", artifacts)
+            interpretation = Path(artifacts["kg_heldout_interpretation_scaffold"]).read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("transfer summary skipped", interpretation.lower())
+
+    def test_auto_detection_uses_matching_selected_settings_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            results_csv = tmp / "results" / "heldout_result_fixture.csv"
+            results_csv.parent.mkdir(parents=True, exist_ok=True)
+            self._write_results_csv(results_csv)
+
+            matching = tmp / "results" / "comparisons" / "matching" / "heldout_selected_settings.json"
+            mismatched = tmp / "results" / "comparisons" / "mismatched" / "heldout_selected_settings.json"
+            self._write_selected_settings(matching)
+            mismatched_payload = {
+                "heldout_datasets": ["other_dataset"],
+                "selected_settings": {
+                    "tfidf": {"heldout_score": 0.1, "mu": 0.1, "sigma": 0.1},
+                    "bm25": {"heldout_score": 0.1, "mu": 0.1, "sigma": 0.1},
+                },
+            }
+            mismatched.parent.mkdir(parents=True, exist_ok=True)
+            mismatched.write_text(
+                json.dumps(mismatched_payload, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(tmp)
+                artifacts = generate_kg_heldout_reporting(
+                    results_csv_path=None,
+                    output_dir=tmp / "comparisons",
+                    selected_settings_path=None,
+                )
+            finally:
+                os.chdir(old_cwd)
+
+            self.assertIn("kg_heldout_transfer_summary", artifacts)
+
+    def test_explicit_malformed_selected_settings_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            results_csv = tmp / "heldout_result_fixture.csv"
+            selected_json = tmp / "heldout_selected_settings.json"
+            self._write_results_csv(results_csv)
+            selected_json.write_text("{not-json}\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                KgHeldoutReportingValidationError,
+                "Malformed selected settings JSON",
+            ):
+                generate_kg_heldout_reporting(
+                    results_csv_path=results_csv,
+                    output_dir=tmp / "comparisons",
+                    selected_settings_path=selected_json,
+                )
+
+    def test_missing_entity_type_or_method_rows_raise(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            bad_csv = tmp / "bad.csv"
+            self._write_results_csv(bad_csv)
+            with bad_csv.open(encoding="utf-8") as csv_file:
+                rows = list(csv.DictReader(csv_file))
+            filtered_rows = [row for row in rows if row["entity_type"] != "predicate"]
+
+            with bad_csv.open("w", encoding="utf-8", newline="") as csv_file:
+                writer = csv.DictWriter(csv_file, fieldnames=list(filtered_rows[0].keys()))
+                writer.writeheader()
+                writer.writerows(filtered_rows)
+
+            with self.assertRaisesRegex(
+                KgHeldoutReportingValidationError,
+                "requires exactly these entity types",
+            ):
+                generate_kg_heldout_reporting(
+                    results_csv_path=bad_csv,
+                    output_dir=tmp / "comparisons",
+                )

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -439,6 +439,70 @@ heldout:
         self.assertIn("Error: ValueError: bad heldout input", stderr.getvalue())
         self.assertIn("CLI execution failed", "\n".join(captured.output))
 
+    def test_report_heldout_kg_explicit_args(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            results_csv = tmp / "heldout_result_fixture.csv"
+            selected_json = tmp / "heldout_selected_settings.json"
+            output_dir = tmp / "comparisons"
+            stdout = io.StringIO()
+
+            with patch(
+                "src.main.generate_kg_heldout_reporting",
+                return_value={"output_dir": output_dir},
+            ) as report_mock:
+                with contextlib.redirect_stdout(stdout):
+                    exit_code = main(
+                        [
+                            "report-heldout-kg",
+                            "--results-csv",
+                            str(results_csv),
+                            "--selected-settings-json",
+                            str(selected_json),
+                            "--output-dir",
+                            str(output_dir),
+                        ]
+                    )
+
+            self.assertEqual(exit_code, 0)
+            report_mock.assert_called_once_with(
+                results_csv_path=str(results_csv),
+                output_dir=str(output_dir),
+                selected_settings_path=str(selected_json),
+            )
+            self.assertIn(f"Held-Out KG Report Dir: {output_dir}", stdout.getvalue())
+
+    def test_report_heldout_kg_default_args(self) -> None:
+        stdout = io.StringIO()
+        with patch(
+            "src.main.generate_kg_heldout_reporting",
+            return_value={"output_dir": Path("results/comparisons/heldout_result_x")},
+        ) as report_mock:
+            with contextlib.redirect_stdout(stdout):
+                exit_code = main(["report-heldout-kg"])
+
+        self.assertEqual(exit_code, 0)
+        report_mock.assert_called_once_with(
+            results_csv_path=None,
+            output_dir="results/comparisons",
+            selected_settings_path=None,
+        )
+        self.assertIn("Held-Out KG Report Dir:", stdout.getvalue())
+
+    def test_report_heldout_kg_failure_path(self) -> None:
+        stderr = io.StringIO()
+        with self.assertLogs("src.main", level="ERROR") as captured:
+            with patch(
+                "src.main.generate_kg_heldout_reporting",
+                side_effect=ValueError("bad heldout reporting input"),
+            ):
+                with contextlib.redirect_stderr(stderr):
+                    exit_code = main(["report-heldout-kg"])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("Error: ValueError: bad heldout reporting input", stderr.getvalue())
+        self.assertIn("CLI execution failed", "\n".join(captured.output))
+
     def test_run_heldout_kg_explicit_args(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
@@ -778,6 +842,7 @@ heldout:
         self.assertIn("depth-analysis", help_text)
         self.assertIn("bm25-sensitivity", help_text)
         self.assertIn("select-heldout-settings", help_text)
+        self.assertIn("report-heldout-kg", help_text)
         self.assertIn("run-heldout-kg", help_text)
         self.assertIn("full-run", help_text)
         self.assertIn("run", help_text)


### PR DESCRIPTION
## Summary
- add a dedicated held-out KG reporting module and `report-heldout-kg` CLI command
- generate per-type, macro, micro, reduction/effectiveness, and interpretation artifacts from held-out KG results
- add optional development-to-held-out transfer summary generation with dataset-matched selected-settings auto-detection

## Testing
- ./venv/bin/python3.12 -m unittest tests.test_kg_heldout_reporting tests.test_main_cli -v
- ./venv/bin/python3.12 -m unittest tests.test_kg_heldout_reporting tests.test_heldout_selection tests.test_heldout_kg_runner tests.test_main_cli -v

Closes #36
