### PR TITLE
feat: add held-out full-run workflow integration (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,46 @@ Generated files:
 - `heldout_selected_settings.json`
 - `heldout_selection_manifest.md`
 
+## End-to-End Held-Out KG Workflow
+
+Held-out track evaluation in this project means the final KG assessment is run only after
+hyperparameters have been frozen from development-track results. KG-track results are never
+used to tune TF-IDF or BM25 settings.
+
+Protocol rules:
+
+- **No KG tuning**: final TF-IDF and BM25 settings must come from the development-track
+  selection workflow.
+- **Entity-type-separated evaluation**: held-out KG execution evaluates `class`,
+  `predicate`, and `instance` partitions separately.
+- **Candidate Reduction Ratio**:
+  - `1 - min(k_max, |T_type|) / |T_type|`
+- **Macro summary**:
+  - unweighted average across `class`, `predicate`, and `instance`
+- **Micro summary**:
+  - gold-weighted average across held-out dataset-type rows
+
+Fully automated workflow:
+
+```bash
+python -m src.main heldout-full-run --config-path config/runtime.yaml --dev-results-csv results/result_YYYYMMDD_HHMMSS_<gitsha>.csv
+```
+
+Manual step-by-step workflow:
+
+```bash
+python -m src.main select-heldout-settings --results-csv results/result_YYYYMMDD_HHMMSS_<gitsha>.csv --config-path config/runtime.yaml
+python -m src.main run-heldout-kg --config-path config/runtime.yaml --selected-settings-json results/comparisons/result_YYYYMMDD_HHMMSS_<gitsha>/heldout_selected_settings.json
+python -m src.main report-heldout-kg --results-csv results/heldout_result_YYYYMMDD_HHMMSS_<gitsha>.csv --selected-settings-json results/comparisons/result_YYYYMMDD_HHMMSS_<gitsha>/heldout_selected_settings.json --output-dir results/comparisons
+```
+
+Artifact handoff:
+
+- selection produces `heldout_selected_settings.json`
+- held-out KG execution consumes that selected-settings artifact and produces `heldout_result_*.csv`
+- held-out reporting consumes the held-out CSV and the selected-settings artifact
+- `heldout-full-run` writes `heldout_full_run_manifest.txt` under the final held-out report directory
+
 ## Held-Out KG Runner
 
 Use the dedicated held-out KG runner to evaluate frozen TF-IDF and BM25 settings by
@@ -524,6 +564,28 @@ Generated files:
 - `kg_heldout_reduction_effectiveness.csv`
 - `kg_heldout_interpretation_scaffold.md`
 - `kg_heldout_transfer_summary.csv` when a compatible selected-settings artifact is available
+
+## Held-Out Full Run
+
+Use the explicit held-out orchestrator to run selection, held-out KG execution, and
+held-out reporting in one command without mixing this protocol into the development
+`full-run` workflow.
+
+With development results CSV and default output locations:
+
+```bash
+python -m src.main heldout-full-run --config-path config/runtime.yaml --dev-results-csv results/result_YYYYMMDD_HHMMSS_<gitsha>.csv
+```
+
+With explicit selected-settings or held-out results overrides:
+
+```bash
+python -m src.main heldout-full-run --config-path config/runtime.yaml --selected-settings-json results/comparisons/result_YYYYMMDD_HHMMSS_<gitsha>/heldout_selected_settings.json --heldout-results-csv results/heldout_result_YYYYMMDD_HHMMSS_<gitsha>.csv --output-dir results/comparisons
+```
+
+Generated provenance file:
+
+- `heldout_full_run_manifest.txt`
 
 ## Logging
 

--- a/src/main.py
+++ b/src/main.py
@@ -5,14 +5,33 @@ from __future__ import annotations
 import argparse
 from datetime import datetime
 import logging
+import json
+import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from src.experiments.experiment_runner import run_experiments
 from src.logging_utils import setup_logging
 
 logger = logging.getLogger("src.main")
+
+if TYPE_CHECKING:
+    from src.experiments.heldout_kg_runner import HeldoutKgResultRecord
+
+
+def _get_git_short_sha() -> str:
+    repo_root = Path(__file__).resolve().parents[1]
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=repo_root,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (subprocess.SubprocessError, OSError):
+        return "nogit"
 
 
 def generate_heldout_selection(
@@ -72,7 +91,7 @@ def run_heldout_kg_experiments(
     selected_settings_path: str | Path | None,
     output_csv_path: str | Path | None,
     show_progress: bool | None,
-) -> list[dict[str, object]]:
+) -> list[HeldoutKgResultRecord]:
     from src.experiments.heldout_kg_runner import (
         run_heldout_kg_experiments as _impl,
     )
@@ -266,6 +285,60 @@ def _build_run_heldout_kg_parser(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _build_heldout_full_run_parser(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--config-path",
+        default="config/runtime.yaml",
+        help="Path to runtime YAML config (default: config/runtime.yaml).",
+    )
+    parser.add_argument(
+        "--dev-results-csv",
+        default=None,
+        help=(
+            "Path to development results CSV used for held-out selection. If omitted, the latest "
+            "results/result_*.csv is used when selection runs."
+        ),
+    )
+    parser.add_argument(
+        "--selected-settings-json",
+        default=None,
+        help=(
+            "Optional heldout_selected_settings.json override. If provided, the selection stage is skipped."
+        ),
+    )
+    parser.add_argument(
+        "--heldout-results-csv",
+        default=None,
+        help=(
+            "Optional held-out KG results CSV override. If provided, the held-out KG run stage is skipped."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="results/comparisons",
+        help="Directory where held-out report artifacts are written (default: results/comparisons).",
+    )
+    parser.add_argument(
+        "--output-csv-path",
+        default=None,
+        help=(
+            "Explicit output CSV path for the held-out KG run stage. Ignored when --heldout-results-csv "
+            "is provided."
+        ),
+    )
+    progress_group = parser.add_mutually_exclusive_group()
+    progress_group.add_argument(
+        "--progress",
+        action="store_true",
+        help="Force-enable progress bars for the held-out KG run stage.",
+    )
+    progress_group.add_argument(
+        "--no-progress",
+        action="store_true",
+        help="Force-disable progress bars for the held-out KG run stage.",
+    )
+
+
 def _build_full_run_parser(parser: argparse.ArgumentParser) -> None:
     _build_run_parser(parser)
     parser.add_argument(
@@ -325,6 +398,12 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Run frozen held-out KG evaluation by entity type.",
     )
     _build_run_heldout_kg_parser(heldout_run_parser)
+
+    heldout_full_run_parser = subparsers.add_parser(
+        "heldout-full-run",
+        help="Run the full held-out KG workflow: selection, held-out execution, and reporting.",
+    )
+    _build_heldout_full_run_parser(heldout_full_run_parser)
 
     full_run_parser = subparsers.add_parser(
         "full-run",
@@ -501,6 +580,205 @@ def _run_heldout_kg_cli(args: argparse.Namespace) -> int:
     return 0
 
 
+def _resolve_existing_file(path_value: str | Path, *, label: str) -> Path:
+    path = Path(path_value)
+    if not path.exists():
+        raise FileNotFoundError(f"{label} not found: {path}")
+    return path.resolve()
+
+
+def _load_selected_settings_source_csv(selected_settings_path: Path) -> Path | None:
+    try:
+        payload = json.loads(selected_settings_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    source_csv = payload.get("source_csv")
+    if not isinstance(source_csv, str) or not source_csv:
+        return None
+    return Path(source_csv).resolve()
+
+
+def _resolve_heldout_manifest_dir(
+    *,
+    output_dir: str | Path,
+    report_output_dir: Path | None,
+    heldout_results_csv: Path | None,
+    heldout_results_csv_arg: str | Path | None,
+    output_csv_path_arg: str | Path | None,
+) -> Path:
+    if report_output_dir is not None:
+        return report_output_dir.resolve()
+    if heldout_results_csv is not None:
+        return Path(output_dir).resolve() / heldout_results_csv.stem
+    if heldout_results_csv_arg is not None:
+        return Path(output_dir).resolve() / Path(heldout_results_csv_arg).stem
+    if output_csv_path_arg is not None:
+        return Path(output_dir).resolve() / Path(output_csv_path_arg).stem
+    return Path(output_dir).resolve() / "heldout_full_run_partial"
+
+
+def _run_heldout_full_run_cli(args: argparse.Namespace) -> int:
+    started_at = datetime.now()
+    start_perf = time.perf_counter()
+    show_progress = _resolve_show_progress(args)
+    stage_status: dict[str, str] = {
+        "select_heldout_settings": "not_run",
+        "run_heldout_kg": "not_run",
+        "report_heldout_kg": "not_run",
+    }
+
+    selected_settings_path: Path
+    heldout_results_csv: Path
+    development_results_csv: Path | None = None
+    report_output_dir: Path | None = None
+    caught_exc: Exception | None = None
+
+    try:
+        if args.selected_settings_json:
+            selected_settings_path = _resolve_existing_file(
+                args.selected_settings_json,
+                label="Selected settings JSON",
+            )
+            development_results_csv = _load_selected_settings_source_csv(selected_settings_path)
+            stage_status["select_heldout_settings"] = "skipped"
+        else:
+            logger.info(
+                "Starting heldout-full-run stage=%s results_csv=%s config_path=%s output_dir=%s",
+                "select_heldout_settings",
+                args.dev_results_csv,
+                args.config_path,
+                args.output_dir,
+            )
+            selection_artifacts = generate_heldout_selection(
+                results_csv_path=args.dev_results_csv,
+                config_path=args.config_path,
+                output_dir=args.output_dir,
+            )
+            selected_settings_path = Path(selection_artifacts["heldout_selected_settings"]).resolve()
+            development_results_csv = Path(selection_artifacts["source_csv"]).resolve()
+            stage_status["select_heldout_settings"] = "success"
+            logger.info("Completed heldout-full-run stage=%s", "select_heldout_settings")
+
+        if args.heldout_results_csv:
+            heldout_results_csv = _resolve_existing_file(
+                args.heldout_results_csv,
+                label="Held-out results CSV",
+            )
+            stage_status["run_heldout_kg"] = "skipped"
+        else:
+            logger.info(
+                "Starting heldout-full-run stage=%s config_path=%s selected_settings=%s output_csv_path=%s progress=%s",
+                "run_heldout_kg",
+                args.config_path,
+                selected_settings_path,
+                args.output_csv_path,
+                show_progress,
+            )
+            existing_files = (
+                _collect_existing_heldout_result_files()
+                if args.output_csv_path is None
+                else set()
+            )
+            run_heldout_kg_experiments(
+                config_path=args.config_path,
+                selected_settings_path=selected_settings_path,
+                output_csv_path=args.output_csv_path,
+                show_progress=show_progress,
+            )
+            heldout_results_csv = (
+                Path(args.output_csv_path).resolve()
+                if args.output_csv_path
+                else _resolve_new_heldout_result_file(existing_files)
+            )
+            if not heldout_results_csv.exists():
+                raise FileNotFoundError(
+                    f"Expected held-out output CSV was not created: {heldout_results_csv}"
+                )
+            stage_status["run_heldout_kg"] = "success"
+            logger.info("Completed heldout-full-run stage=%s", "run_heldout_kg")
+
+        logger.info(
+            "Starting heldout-full-run stage=%s heldout_results_csv=%s selected_settings=%s output_dir=%s",
+            "report_heldout_kg",
+            heldout_results_csv,
+            selected_settings_path,
+            args.output_dir,
+        )
+        report_artifacts = generate_kg_heldout_reporting(
+            results_csv_path=heldout_results_csv,
+            output_dir=args.output_dir,
+            selected_settings_path=selected_settings_path,
+        )
+        report_output_dir = Path(report_artifacts["output_dir"]).resolve()
+        stage_status["report_heldout_kg"] = "success"
+        logger.info("Completed heldout-full-run stage=%s", "report_heldout_kg")
+    except Exception as exc:
+        caught_exc = exc
+        failed_stage = next(
+            (
+                stage
+                for stage in ("select_heldout_settings", "run_heldout_kg", "report_heldout_kg")
+                if stage_status[stage] == "not_run"
+            ),
+            "unknown",
+        )
+        if failed_stage != "unknown":
+            stage_status[failed_stage] = "failed"
+        logger.exception(
+            "Heldout-full-run stage failed stage=%s dev_results_csv=%s config_path=%s selected_settings_json=%s heldout_results_csv=%s output_dir=%s error=%s: %s",
+            failed_stage,
+            args.dev_results_csv,
+            args.config_path,
+            args.selected_settings_json,
+            args.heldout_results_csv,
+            args.output_dir,
+            type(exc).__name__,
+            exc,
+        )
+    ended_at = datetime.now()
+    elapsed_seconds = time.perf_counter() - start_perf
+    manifest_dir = _resolve_heldout_manifest_dir(
+        output_dir=args.output_dir,
+        report_output_dir=report_output_dir,
+        heldout_results_csv=heldout_results_csv if "heldout_results_csv" in locals() else None,
+        heldout_results_csv_arg=args.heldout_results_csv,
+        output_csv_path_arg=args.output_csv_path,
+    )
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = manifest_dir / "heldout_full_run_manifest.txt"
+    manifest_path.write_text(
+        "\n".join(
+            [
+                f"generated_at_start={started_at.isoformat(timespec='seconds')}",
+                f"generated_at_end={ended_at.isoformat(timespec='seconds')}",
+                f"elapsed_seconds={elapsed_seconds:.6f}",
+                f"git_sha={_get_git_short_sha()}",
+                f"config_path={Path(args.config_path).resolve()}",
+                f"development_results_csv={development_results_csv if development_results_csv is not None else ''}",
+                f"selected_settings_json={selected_settings_path.resolve() if 'selected_settings_path' in locals() else ''}",
+                f"heldout_results_csv={heldout_results_csv.resolve() if 'heldout_results_csv' in locals() else ''}",
+                f"report_output_dir={report_output_dir if report_output_dir is not None else ''}",
+                f"stage_select_heldout_settings={stage_status['select_heldout_settings']}",
+                f"stage_run_heldout_kg={stage_status['run_heldout_kg']}",
+                f"stage_report_heldout_kg={stage_status['report_heldout_kg']}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    if caught_exc is not None:
+        raise caught_exc
+
+    print(f"Selected Settings JSON: {selected_settings_path}")
+    print(f"Held-Out KG Results CSV: {heldout_results_csv}")
+    print(f"Held-Out KG Report Dir: {report_output_dir}")
+    print(f"Held-Out Full Run Manifest: {manifest_path}")
+    return 0
+
+
 def _run_full_run_cli(args: argparse.Namespace) -> int:
     started_at = datetime.now()
     start_perf = time.perf_counter()
@@ -667,6 +945,8 @@ def main(argv: list[str] | None = None) -> int:
             return _run_report_heldout_kg_cli(args)
         if args.command == "run-heldout-kg":
             return _run_heldout_kg_cli(args)
+        if args.command == "heldout-full-run":
+            return _run_heldout_full_run_cli(args)
         if args.command == "full-run":
             return _run_full_run_cli(args)
         return _run_experiment_cli(args)

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -576,6 +576,213 @@ heldout:
         self.assertIn("Error: ValueError: bad heldout kg input", stderr.getvalue())
         self.assertIn("CLI execution failed", "\n".join(captured.output))
 
+    def test_heldout_full_run_wires_same_run_artifacts_and_writes_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            selected_settings = tmp / "comparisons" / "result_dev" / "heldout_selected_settings.json"
+            selected_settings.parent.mkdir(parents=True, exist_ok=True)
+            selected_settings.write_text('{"source_csv": "/tmp/dev.csv"}\n', encoding="utf-8")
+            heldout_csv = tmp / "results" / "heldout_result_fixture.csv"
+            heldout_csv.parent.mkdir(parents=True, exist_ok=True)
+            heldout_csv.write_text("track,version\n", encoding="utf-8")
+            report_output_dir = tmp / "comparisons" / "heldout_result_fixture"
+            report_output_dir.mkdir(parents=True, exist_ok=True)
+            stdout = io.StringIO()
+
+            with patch(
+                "src.main.generate_heldout_selection",
+                return_value={
+                    "source_csv": tmp / "results" / "result_dev.csv",
+                    "heldout_selected_settings": selected_settings,
+                },
+            ) as selection_mock:
+                with patch("src.main.run_heldout_kg_experiments", return_value=[]) as heldout_mock:
+                    with patch(
+                        "src.main._resolve_new_heldout_result_file",
+                        return_value=heldout_csv.resolve(),
+                    ):
+                        with patch(
+                            "src.main.generate_kg_heldout_reporting",
+                            return_value={"output_dir": report_output_dir},
+                        ) as report_mock:
+                            with patch("src.main._get_git_short_sha", return_value="deadbeef"):
+                                with contextlib.redirect_stdout(stdout):
+                                    exit_code = main(
+                                        [
+                                            "heldout-full-run",
+                                            "--config-path",
+                                            str(tmp / "runtime.yaml"),
+                                            "--dev-results-csv",
+                                            str(tmp / "results" / "result_dev.csv"),
+                                            "--output-dir",
+                                            str(tmp / "comparisons"),
+                                            "--no-progress",
+                                        ]
+                                    )
+
+            self.assertEqual(exit_code, 0)
+            selection_mock.assert_called_once_with(
+                results_csv_path=str(tmp / "results" / "result_dev.csv"),
+                config_path=str(tmp / "runtime.yaml"),
+                output_dir=str(tmp / "comparisons"),
+            )
+            heldout_mock.assert_called_once_with(
+                config_path=str(tmp / "runtime.yaml"),
+                selected_settings_path=selected_settings.resolve(),
+                output_csv_path=None,
+                show_progress=False,
+            )
+            report_mock.assert_called_once_with(
+                results_csv_path=heldout_csv.resolve(),
+                output_dir=str(tmp / "comparisons"),
+                selected_settings_path=selected_settings.resolve(),
+            )
+
+            manifest_path = report_output_dir / "heldout_full_run_manifest.txt"
+            self.assertTrue(manifest_path.exists())
+            manifest_text = manifest_path.read_text(encoding="utf-8")
+            self.assertIn("generated_at_start=", manifest_text)
+            self.assertIn("generated_at_end=", manifest_text)
+            self.assertIn("elapsed_seconds=", manifest_text)
+            self.assertIn("git_sha=deadbeef", manifest_text)
+            self.assertIn(f"config_path={(tmp / 'runtime.yaml').resolve()}", manifest_text)
+            self.assertIn(
+                f"development_results_csv={(tmp / 'results' / 'result_dev.csv').resolve()}",
+                manifest_text,
+            )
+            self.assertIn(f"selected_settings_json={selected_settings.resolve()}", manifest_text)
+            self.assertIn(f"heldout_results_csv={heldout_csv.resolve()}", manifest_text)
+            self.assertIn(f"report_output_dir={report_output_dir.resolve()}", manifest_text)
+            self.assertIn("stage_select_heldout_settings=success", manifest_text)
+            self.assertIn("stage_run_heldout_kg=success", manifest_text)
+            self.assertIn("stage_report_heldout_kg=success", manifest_text)
+            self.assertIn("Held-Out Full Run Manifest:", stdout.getvalue())
+
+    def test_heldout_full_run_skips_selection_when_selected_settings_is_provided(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            selected_settings = tmp / "heldout_selected_settings.json"
+            selected_settings.write_text(
+                f'{{"source_csv": "{(tmp / "results" / "result_dev.csv").resolve()}"}}\n',
+                encoding="utf-8",
+            )
+            heldout_csv = tmp / "results" / "heldout_result_fixture.csv"
+            heldout_csv.parent.mkdir(parents=True, exist_ok=True)
+            heldout_csv.write_text("track,version\n", encoding="utf-8")
+            output_root = tmp / "comparisons" / "heldout_result_fixture"
+            output_root.mkdir(parents=True, exist_ok=True)
+
+            with patch("src.main.generate_heldout_selection") as selection_mock:
+                with patch("src.main.run_heldout_kg_experiments", return_value=[]) as heldout_mock:
+                    with patch(
+                        "src.main._resolve_new_heldout_result_file",
+                        return_value=heldout_csv.resolve(),
+                    ):
+                        with patch(
+                            "src.main.generate_kg_heldout_reporting",
+                            return_value={"output_dir": output_root},
+                        ) as report_mock:
+                            exit_code = main(
+                                [
+                                    "heldout-full-run",
+                                    "--config-path",
+                                    str(tmp / "runtime.yaml"),
+                                    "--selected-settings-json",
+                                    str(selected_settings),
+                                ]
+                            )
+
+            self.assertEqual(exit_code, 0)
+            selection_mock.assert_not_called()
+            heldout_mock.assert_called_once()
+            report_mock.assert_called_once_with(
+                results_csv_path=heldout_csv.resolve(),
+                output_dir="results/comparisons",
+                selected_settings_path=selected_settings.resolve(),
+            )
+            manifest_text = (output_root / "heldout_full_run_manifest.txt").read_text(encoding="utf-8")
+            self.assertIn("stage_select_heldout_settings=skipped", manifest_text)
+
+    def test_heldout_full_run_skips_runner_when_heldout_results_is_provided(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            selected_settings = tmp / "comparisons" / "result_dev" / "heldout_selected_settings.json"
+            selected_settings.parent.mkdir(parents=True, exist_ok=True)
+            selected_settings.write_text('{"source_csv": "/tmp/dev.csv"}\n', encoding="utf-8")
+            heldout_csv = tmp / "heldout_result_fixture.csv"
+            heldout_csv.write_text("track,version\n", encoding="utf-8")
+            output_root = tmp / "comparisons" / "heldout_result_fixture"
+            output_root.mkdir(parents=True, exist_ok=True)
+
+            with patch(
+                "src.main.generate_heldout_selection",
+                return_value={
+                    "source_csv": tmp / "results" / "result_dev.csv",
+                    "heldout_selected_settings": selected_settings,
+                },
+            ) as selection_mock:
+                with patch("src.main.run_heldout_kg_experiments") as heldout_mock:
+                    with patch(
+                        "src.main.generate_kg_heldout_reporting",
+                        return_value={"output_dir": output_root},
+                    ) as report_mock:
+                        exit_code = main(
+                            [
+                                "heldout-full-run",
+                                "--heldout-results-csv",
+                                str(heldout_csv),
+                            ]
+                        )
+
+            self.assertEqual(exit_code, 0)
+            selection_mock.assert_called_once()
+            heldout_mock.assert_not_called()
+            report_mock.assert_called_once_with(
+                results_csv_path=heldout_csv.resolve(),
+                output_dir="results/comparisons",
+                selected_settings_path=selected_settings.resolve(),
+            )
+            manifest_text = (output_root / "heldout_full_run_manifest.txt").read_text(encoding="utf-8")
+            self.assertIn("stage_run_heldout_kg=skipped", manifest_text)
+
+    def test_heldout_full_run_fails_fast_when_stage_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            stderr = io.StringIO()
+            with self.assertLogs("src.main", level="ERROR") as captured:
+                with patch(
+                    "src.main.generate_heldout_selection",
+                    side_effect=ValueError("heldout selection failed"),
+                ):
+                    with patch("src.main.run_heldout_kg_experiments") as heldout_mock:
+                        with patch("src.main.generate_kg_heldout_reporting") as report_mock:
+                            with contextlib.redirect_stderr(stderr):
+                                exit_code = main(
+                                    [
+                                        "heldout-full-run",
+                                        "--output-dir",
+                                        str(tmp / "comparisons"),
+                                    ]
+                                )
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn("Error: ValueError: heldout selection failed", stderr.getvalue())
+            self.assertIn("Heldout-full-run stage failed", "\n".join(captured.output))
+            heldout_mock.assert_not_called()
+            report_mock.assert_not_called()
+
+            manifest_path = (
+                tmp
+                / "comparisons"
+                / "heldout_full_run_partial"
+                / "heldout_full_run_manifest.txt"
+            )
+            self.assertTrue(manifest_path.exists())
+            manifest_text = manifest_path.read_text(encoding="utf-8")
+            self.assertIn("stage_select_heldout_settings=failed", manifest_text)
+            self.assertIn("stage_run_heldout_kg=not_run", manifest_text)
+            self.assertIn("stage_report_heldout_kg=not_run", manifest_text)
+
     def test_depth_analysis_explicit_args(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
@@ -844,6 +1051,7 @@ heldout:
         self.assertIn("select-heldout-settings", help_text)
         self.assertIn("report-heldout-kg", help_text)
         self.assertIn("run-heldout-kg", help_text)
+        self.assertIn("heldout-full-run", help_text)
         self.assertIn("full-run", help_text)
         self.assertIn("run", help_text)
 


### PR DESCRIPTION
## Summary
- add an explicit `heldout-full-run` CLI command that orchestrates held-out selection, held-out KG execution, and held-out reporting
- write a held-out full-run manifest with provenance and stage status, including partial-run manifests on failure
- document the end-to-end held-out KG workflow, no-KG-tuning rule, candidate reduction ratio, and macro/micro reporting definitions

## Testing
- ./venv/bin/python3.12 -m unittest tests.test_main_cli -v

Closes #37
