### PR TITLE
refactor: generalize evaluation workflow for named methods (#43)

### DIFF
--- a/src/analysis/bm25_sensitivity.py
+++ b/src/analysis/bm25_sensitivity.py
@@ -7,8 +7,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-import matplotlib
-matplotlib.use("Agg")
+from src.analysis import plot_env as _plot_env  # noqa: F401
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
@@ -30,6 +29,28 @@ BOOTSTRAP_SAMPLES = 1000
 
 class Bm25SensitivityValidationError(ValueError):
     """Raised when BM25 sensitivity input data is invalid."""
+
+
+def _coerce_count(value: object) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        return int(value)
+    raise TypeError(f"Unsupported count value: {value!r}")
+
+
+def _coerce_float(value: object) -> float:
+    if isinstance(value, bool):
+        return float(value)
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        return float(value)
+    raise TypeError(f"Unsupported float value: {value!r}")
 
 
 def _resolve_results_csv(results_csv_path: str | Path | None) -> Path:
@@ -470,8 +491,8 @@ def _write_interpretation_scaffold(
         rank1 = top_settings.iloc[0]
         rank2 = top_settings.iloc[1]
         ci_overlap_with_rank2 = not (
-            float(rank2["mrr_ci_upper"]) < float(rank1["mrr_ci_lower"])
-            or float(rank2["mrr_ci_lower"]) > float(rank1["mrr_ci_upper"])
+            _coerce_float(rank2["mrr_ci_upper"]) < _coerce_float(rank1["mrr_ci_lower"])
+            or _coerce_float(rank2["mrr_ci_lower"]) > _coerce_float(rank1["mrr_ci_upper"])
         )
     lines = [
         "# BM25 Sensitivity Interpretation Scaffold",
@@ -483,8 +504,8 @@ def _write_interpretation_scaffold(
     if best_row is not None:
         lines.append(
             f"- Top setting by mean MRR: (k1={best_row['k1']}, b={best_row['b']}) "
-            f"with mean MRR={float(best_row['mrr_mean']):.4f} "
-            f"[95% CI: {float(best_row['mrr_ci_lower']):.4f}, {float(best_row['mrr_ci_upper']):.4f}]."
+            f"with mean MRR={_coerce_float(best_row['mrr_mean']):.4f} "
+            f"[95% CI: {_coerce_float(best_row['mrr_ci_lower']):.4f}, {_coerce_float(best_row['mrr_ci_upper']):.4f}]."
         )
     lines.extend(
         [
@@ -497,13 +518,13 @@ def _write_interpretation_scaffold(
     if most_stable_track is not None and most_sensitive_track is not None:
         lines.append(
             f"- Most stable track by MRR std: {most_stable_track['track']} "
-            f"(std={float(most_stable_track['mrr_std']):.4f}, "
-            f"datasets={int(most_stable_track['datasets_in_track'])})."
+            f"(std={_coerce_float(most_stable_track['mrr_std']):.4f}, "
+            f"datasets={_coerce_count(most_stable_track['datasets_in_track'])})."
         )
         lines.append(
             f"- Most sensitive track by MRR std: {most_sensitive_track['track']} "
-            f"(std={float(most_sensitive_track['mrr_std']):.4f}, "
-            f"datasets={int(most_sensitive_track['datasets_in_track'])})."
+            f"(std={_coerce_float(most_sensitive_track['mrr_std']):.4f}, "
+            f"datasets={_coerce_count(most_sensitive_track['datasets_in_track'])})."
         )
         lines.append(
             "- Caution: stability comparisons across tracks should account for "

--- a/src/analysis/depth_analysis.py
+++ b/src/analysis/depth_analysis.py
@@ -5,12 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 
-from src.analysis.plot_env import configure_plot_environment
-
-configure_plot_environment()
-
-import matplotlib
-matplotlib.use("Agg")
+from src.analysis import plot_env as _plot_env  # noqa: F401
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
@@ -33,6 +28,28 @@ REQUIRED_COLUMNS = {
 
 class DepthAnalysisValidationError(ValueError):
     """Raised when depth-analysis input data is invalid."""
+
+
+def _coerce_count(value: object) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        return int(value)
+    raise TypeError(f"Unsupported count value: {value!r}")
+
+
+def _coerce_float(value: object) -> float:
+    if isinstance(value, bool):
+        return float(value)
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        return float(value)
+    raise TypeError(f"Unsupported float value: {value!r}")
 
 
 def _resolve_results_csv(results_csv_path: str | Path | None) -> Path:
@@ -96,21 +113,22 @@ def _select_best_settings(prepared: pd.DataFrame) -> pd.DataFrame:
 def _build_marginal_gains(best_settings: pd.DataFrame) -> pd.DataFrame:
     rows: list[dict[str, object]] = []
     for row in best_settings.itertuples(index=False):
+        candidate_size = _coerce_count(row.candidate_size)
         for from_k, to_k in TRANSITIONS:
             gain = float(getattr(row, f"recall_at_{to_k}") - getattr(row, f"recall_at_{from_k}"))
-            capped = int(row.candidate_size) < to_k
+            capped = candidate_size < to_k
             rows.append(
                 {
                     "track": str(row.track),
                     "dataset": str(row.dataset),
                     "method": str(row.method),
-                    "candidate_size": int(row.candidate_size),
+                    "candidate_size": candidate_size,
                     "from_k": from_k,
                     "to_k": to_k,
                     "transition": _transition_label(from_k, to_k),
                     "marginal_gain": gain,
                     "is_capped_before_to": capped,
-                    "effective_to_k": min(int(row.candidate_size), to_k),
+                    "effective_to_k": min(candidate_size, to_k),
                 }
             )
     return pd.DataFrame(rows).sort_values(
@@ -153,11 +171,12 @@ def _build_transition_coverage(marginal_gains: pd.DataFrame) -> pd.DataFrame:
     for transition, group in marginal_gains.groupby("transition", sort=False):
         total = int(len(group))
         capped = int(group["is_capped_before_to"].sum())
+        to_k = _coerce_count(group["to_k"].iloc[0])
         rows.append(
             {
                 "method": "ALL",
                 "transition": str(transition),
-                "to_k": int(group["to_k"].iloc[0]),
+                "to_k": to_k,
                 "total_count": total,
                 "full_coverage_count": total - capped,
                 "capped_count": capped,
@@ -168,11 +187,12 @@ def _build_transition_coverage(marginal_gains: pd.DataFrame) -> pd.DataFrame:
     for (method, transition), group in marginal_gains.groupby(["method", "transition"], sort=False):
         total = int(len(group))
         capped = int(group["is_capped_before_to"].sum())
+        to_k = _coerce_count(group["to_k"].iloc[0])
         rows.append(
             {
                 "method": str(method),
                 "transition": str(transition),
-                "to_k": int(group["to_k"].iloc[0]),
+                "to_k": to_k,
                 "total_count": total,
                 "full_coverage_count": total - capped,
                 "capped_count": capped,
@@ -194,7 +214,7 @@ def _draw_recall_gain_curves(best_settings: pd.DataFrame, output_root: Path) -> 
                 {
                     "method": str(row.method),
                     "k": depth,
-                    "recall": float(getattr(row, f"recall_at_{depth}")),
+                    "recall": _coerce_float(getattr(row, f"recall_at_{depth}")),
                 }
             )
     plot_data = pd.DataFrame(rows)
@@ -290,7 +310,7 @@ def _write_interpretation_scaffold(
 
     coverage_overall = coverage[coverage["method"] == "ALL"].copy().set_index("transition")
     capped_20_50 = (
-        float(coverage_overall.loc["20->50", "capped_rate"])
+        _coerce_float(coverage_overall.loc["20->50", "capped_rate"])
         if "20->50" in coverage_overall.index
         else 0.0
     )

--- a/src/analysis/heldout_selection.py
+++ b/src/analysis/heldout_selection.py
@@ -10,9 +10,10 @@ from typing import Any
 import pandas as pd
 
 from src.config_loader import load_runtime_config
+from src.method_registry import heldout_selected_method_names
 
 REQUIRED_COLUMNS = {"dataset", "track", "method", "hyperparameters", "mrr"}
-SUPPORTED_METHODS = {"tfidf", "bm25"}
+SUPPORTED_METHODS = tuple(heldout_selected_method_names())
 
 
 class HeldoutSelectionValidationError(ValueError):
@@ -228,7 +229,7 @@ def _build_method_summary(method_frame: pd.DataFrame, *, lambda_penalty: float) 
 
 def _build_selection_summary(frame: pd.DataFrame, *, lambda_penalty: float) -> pd.DataFrame:
     method_summaries: list[pd.DataFrame] = []
-    for method in sorted(SUPPORTED_METHODS):
+    for method in SUPPORTED_METHODS:
         method_frame = frame[frame["method"] == method].copy()
         if method_frame.empty:
             raise HeldoutSelectionValidationError(f"Missing method rows for '{method}'.")
@@ -242,7 +243,7 @@ def _build_selection_summary(frame: pd.DataFrame, *, lambda_penalty: float) -> p
 
 def _selected_settings_payload(summary: pd.DataFrame) -> dict[str, dict[str, object]]:
     payload: dict[str, dict[str, object]] = {}
-    for method in sorted(SUPPORTED_METHODS):
+    for method in SUPPORTED_METHODS:
         selected = summary[(summary["method"] == method) & (summary["selected"])].reset_index(drop=True)
         if len(selected) != 1:
             raise HeldoutSelectionValidationError(
@@ -339,6 +340,7 @@ def generate_heldout_selection(
                 "source_csv": str(source_csv),
                 "config_path": str(Path(config_path).resolve()),
                 "policy": policy,
+                "selected_method_names": list(SUPPORTED_METHODS),
                 "selected_settings": selected_settings,
                 "heldout_datasets": sorted(runtime_config.heldout_datasets.keys()),
             },

--- a/src/analysis/kg_heldout_reporting.py
+++ b/src/analysis/kg_heldout_reporting.py
@@ -11,6 +11,8 @@ from typing import Any
 
 import pandas as pd
 
+from src.method_registry import PRIMARY_COMPARISON_METHODS, ordered_method_names, supports_primary_comparison
+
 logger = logging.getLogger(__name__)
 
 REQUIRED_COLUMNS = {
@@ -27,12 +29,21 @@ REQUIRED_COLUMNS = {
     "mrr",
     "runtime_seconds",
 }
-REQUIRED_METHODS = {"tfidf", "bm25"}
 REQUIRED_ENTITY_TYPES = {"class", "predicate", "instance"}
 
 
 class KgHeldoutReportingValidationError(ValueError):
     """Raised when held-out reporting inputs are invalid."""
+
+
+def _coerce_float(value: object) -> float:
+    if isinstance(value, bool):
+        return float(value)
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        return float(value)
+    raise TypeError(f"Unsupported float value: {value!r}")
 
 
 def _resolve_results_csv(results_csv_path: str | Path | None) -> Path:
@@ -110,7 +121,7 @@ def _find_recall_columns(frame: pd.DataFrame) -> list[str]:
     return sorted(recall_columns, key=lambda column: int(column.removeprefix("recall_at_")))
 
 
-def _validate_results_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, list[str]]:
+def _validate_results_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, list[str], list[str]]:
     missing_columns = sorted(REQUIRED_COLUMNS - set(frame.columns))
     if missing_columns:
         raise KgHeldoutReportingValidationError(
@@ -140,11 +151,10 @@ def _validate_results_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, list[str
     for column in recall_columns:
         validated[column] = validated[column].astype(float)
 
-    methods = set(validated["method"].unique())
-    if methods != REQUIRED_METHODS:
+    methods = ordered_method_names(validated["method"].unique())
+    if not methods:
         raise KgHeldoutReportingValidationError(
-            "Held-out KG reporting requires exactly these methods: "
-            + ", ".join(sorted(REQUIRED_METHODS))
+            "Held-out KG reporting requires at least one method row."
         )
 
     entity_types = set(validated["entity_type"].unique())
@@ -159,11 +169,11 @@ def _validate_results_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, list[str
         .nunique()
         .reset_index(name="method_count")
     )
-    incomplete = coverage[coverage["method_count"] != len(REQUIRED_METHODS)]
+    incomplete = coverage[coverage["method_count"] != len(methods)]
     if not incomplete.empty:
         bad = incomplete.iloc[0]
         raise KgHeldoutReportingValidationError(
-            "Each dataset/entity_type pair must have one TF-IDF row and one BM25 row. "
+            "Each dataset/entity_type pair must have one row for every reported method. "
             f"Found incomplete coverage for dataset='{bad['dataset']}', entity_type='{bad['entity_type']}'."
         )
 
@@ -183,10 +193,14 @@ def _validate_results_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, list[str
 
     return validated.sort_values(
         ["track", "dataset", "entity_type", "method"], kind="mergesort"
-    ).reset_index(drop=True), recall_columns
+    ).reset_index(drop=True), recall_columns, methods
 
 
-def _build_by_type_summary(frame: pd.DataFrame, recall_columns: list[str]) -> pd.DataFrame:
+def _build_by_type_summary(
+    frame: pd.DataFrame,
+    recall_columns: list[str],
+    methods: list[str],
+) -> pd.DataFrame:
     aggregation: dict[str, str] = {
         "dataset": "count",
         "gold_count": "sum",
@@ -213,7 +227,13 @@ def _build_by_type_summary(frame: pd.DataFrame, recall_columns: list[str]) -> pd
             }
         )
     )
-    return summary.sort_values(["entity_type", "method"], kind="mergesort").reset_index(drop=True)
+    method_order = {method: index for index, method in enumerate(methods)}
+    summary["_method_order"] = summary["method"].map(
+        lambda value: method_order.get(str(value), len(method_order))
+    )
+    return summary.sort_values(
+        ["entity_type", "_method_order", "method"], kind="mergesort"
+    ).drop(columns="_method_order").reset_index(drop=True)
 
 
 def _delta_row(
@@ -223,16 +243,23 @@ def _delta_row(
     method_column: str = "method",
 ) -> dict[str, object]:
     indexed = frame.set_index(method_column)
-    if "tfidf" not in indexed.index or "bm25" not in indexed.index:
+    if not supports_primary_comparison(indexed.index):
         raise KgHeldoutReportingValidationError("Expected tfidf and bm25 rows for delta computation.")
 
     row: dict[str, object] = {method_column: "delta_tfidf_minus_bm25"}
     for column in value_columns:
-        row[column] = float(indexed.loc["tfidf", column] - indexed.loc["bm25", column])
+        row[column] = float(
+            indexed.loc[PRIMARY_COMPARISON_METHODS[0], column]
+            - indexed.loc[PRIMARY_COMPARISON_METHODS[1], column]
+        )
     return row
 
 
-def _build_macro_summary(by_type_summary: pd.DataFrame, recall_columns: list[str]) -> pd.DataFrame:
+def _build_macro_summary(
+    by_type_summary: pd.DataFrame,
+    recall_columns: list[str],
+    methods: list[str],
+) -> pd.DataFrame:
     value_columns = [
         "dataset_count",
         "gold_count_sum",
@@ -243,7 +270,7 @@ def _build_macro_summary(by_type_summary: pd.DataFrame, recall_columns: list[str
         *(f"{column}_mean" for column in recall_columns),
     ]
     method_rows: list[dict[str, object]] = []
-    for method in sorted(REQUIRED_METHODS):
+    for method in methods:
         group = by_type_summary[by_type_summary["method"] == method].sort_values(
             ["entity_type"], kind="mergesort"
         )
@@ -253,10 +280,11 @@ def _build_macro_summary(by_type_summary: pd.DataFrame, recall_columns: list[str
         method_rows.append(row)
 
     summary = pd.DataFrame(method_rows)
-    summary = pd.concat(
-        [summary, pd.DataFrame([_delta_row(summary, value_columns=value_columns)])],
-        ignore_index=True,
-    )
+    if supports_primary_comparison(methods):
+        summary = pd.concat(
+            [summary, pd.DataFrame([_delta_row(summary, value_columns=value_columns)])],
+            ignore_index=True,
+        )
     summary = summary.rename(
         columns={
             "dataset_count": "dataset_count_macro_mean",
@@ -273,9 +301,13 @@ def _weighted_mean(values: pd.Series, weights: pd.Series) -> float:
     return float((values * weights).sum() / total_weight)
 
 
-def _build_micro_summary(frame: pd.DataFrame, recall_columns: list[str]) -> pd.DataFrame:
+def _build_micro_summary(
+    frame: pd.DataFrame,
+    recall_columns: list[str],
+    methods: list[str],
+) -> pd.DataFrame:
     method_rows: list[dict[str, object]] = []
-    for method in sorted(REQUIRED_METHODS):
+    for method in methods:
         group = frame[frame["method"] == method].sort_values(
             ["track", "dataset", "entity_type"], kind="mergesort"
         )
@@ -305,14 +337,19 @@ def _build_micro_summary(frame: pd.DataFrame, recall_columns: list[str]) -> pd.D
         *recall_columns,
     ]
     summary = pd.DataFrame(method_rows)
-    summary = pd.concat(
-        [summary, pd.DataFrame([_delta_row(summary, value_columns=value_columns)])],
-        ignore_index=True,
-    )
+    if supports_primary_comparison(methods):
+        summary = pd.concat(
+            [summary, pd.DataFrame([_delta_row(summary, value_columns=value_columns)])],
+            ignore_index=True,
+        )
     return summary.sort_values(["method"], kind="mergesort").reset_index(drop=True)
 
 
-def _build_reduction_effectiveness(frame: pd.DataFrame, recall_columns: list[str]) -> pd.DataFrame:
+def _build_reduction_effectiveness(
+    frame: pd.DataFrame,
+    recall_columns: list[str],
+    methods: list[str],
+) -> pd.DataFrame:
     base_columns = [
         "track",
         "version",
@@ -330,8 +367,14 @@ def _build_reduction_effectiveness(frame: pd.DataFrame, recall_columns: list[str
     ]
     enriched = frame[base_columns].copy()
 
+    if not supports_primary_comparison(methods):
+        return enriched.sort_values(
+            ["track", "dataset", "entity_type", "method"], kind="mergesort"
+        ).reset_index(drop=True)
+
+    primary_pair = frame[frame["method"].isin(PRIMARY_COMPARISON_METHODS)].copy()
     paired = (
-        frame.pivot(
+        primary_pair.pivot(
             index=["track", "version", "dataset", "entity_type"],
             columns="method",
             values=["candidate_reduction_ratio", "mrr", *recall_columns],
@@ -340,19 +383,31 @@ def _build_reduction_effectiveness(frame: pd.DataFrame, recall_columns: list[str
     )
 
     def paired_value(row: pd.Series, metric: str, method: str) -> float:
-        return float(paired.loc[(row["track"], row["version"], row["dataset"], row["entity_type"]), (metric, method)])
+        return _coerce_float(
+            paired.loc[
+                (row["track"], row["version"], row["dataset"], row["entity_type"]),
+                (metric, method),
+            ]
+        )
 
-    enriched["other_method"] = enriched["method"].map({"tfidf": "bm25", "bm25": "tfidf"})
+    other_method_map = {
+        PRIMARY_COMPARISON_METHODS[0]: PRIMARY_COMPARISON_METHODS[1],
+        PRIMARY_COMPARISON_METHODS[1]: PRIMARY_COMPARISON_METHODS[0],
+    }
+    enriched["other_method"] = enriched["method"].map(other_method_map)
     for metric in ["candidate_reduction_ratio", "mrr", *recall_columns]:
         delta_column = f"{metric}_delta_vs_other_method"
-        deltas: list[float] = []
+        deltas: list[float | None] = []
         for row in enriched.itertuples(index=False):
             current_method = str(row.method)
+            if current_method not in other_method_map:
+                deltas.append(None)
+                continue
             current_value = paired_value(pd.Series(row._asdict()), metric, current_method)
             other_value = paired_value(
                 pd.Series(row._asdict()),
                 metric,
-                "bm25" if current_method == "tfidf" else "tfidf",
+                other_method_map[current_method],
             )
             deltas.append(float(current_value - other_value))
         enriched[delta_column] = deltas
@@ -366,9 +421,12 @@ def _load_selected_settings_payload(
     selected_settings_path: Path | None,
     *,
     strict: bool,
+    methods: list[str],
 ) -> tuple[dict[str, dict[str, float]] | None, str | None]:
     if selected_settings_path is None:
         return None, "No uniquely matching selected-settings artifact was found; transfer summary skipped."
+    if not supports_primary_comparison(methods):
+        return None, "TF-IDF/BM25 pair not present; transfer summary skipped."
 
     try:
         payload = json.loads(selected_settings_path.read_text(encoding="utf-8"))
@@ -394,7 +452,7 @@ def _load_selected_settings_payload(
     selected_settings = payload["selected_settings"]
     transfer_payload: dict[str, dict[str, float]] = {}
     try:
-        for method in sorted(REQUIRED_METHODS):
+        for method in PRIMARY_COMPARISON_METHODS:
             entry = selected_settings[method]
             transfer_payload[method] = {
                 "development_selection_score": float(entry["heldout_score"]),
@@ -420,21 +478,25 @@ def _build_transfer_summary(
     macro_summary: pd.DataFrame,
     micro_summary: pd.DataFrame,
 ) -> pd.DataFrame:
-    macro_by_method = macro_summary[macro_summary["method"].isin(REQUIRED_METHODS)].set_index("method")
-    micro_by_method = micro_summary[micro_summary["method"].isin(REQUIRED_METHODS)].set_index("method")
+    macro_by_method = macro_summary[
+        macro_summary["method"].isin(PRIMARY_COMPARISON_METHODS)
+    ].set_index("method")
+    micro_by_method = micro_summary[
+        micro_summary["method"].isin(PRIMARY_COMPARISON_METHODS)
+    ].set_index("method")
 
     rows: list[dict[str, object]] = []
-    for method in sorted(REQUIRED_METHODS):
+    for method in PRIMARY_COMPARISON_METHODS:
         development = transfer_payload[method]
-        heldout_macro_mrr = float(macro_by_method.loc[method, "mrr_mean"])
-        heldout_micro_mrr = float(micro_by_method.loc[method, "mrr"])
-        development_mu = float(development["development_mu"])
+        heldout_macro_mrr = _coerce_float(macro_by_method.loc[method, "mrr_mean"])
+        heldout_micro_mrr = _coerce_float(micro_by_method.loc[method, "mrr"])
+        development_mu = _coerce_float(development["development_mu"])
         rows.append(
             {
                 "method": method,
-                "development_selection_score": float(development["development_selection_score"]),
+                "development_selection_score": _coerce_float(development["development_selection_score"]),
                 "development_mu": development_mu,
-                "development_sigma": float(development["development_sigma"]),
+                "development_sigma": _coerce_float(development["development_sigma"]),
                 "heldout_macro_mrr": heldout_macro_mrr,
                 "heldout_micro_mrr": heldout_micro_mrr,
                 "macro_transfer_gap": float(heldout_macro_mrr - development_mu),
@@ -456,27 +518,28 @@ def _write_interpretation_scaffold(
     primary_recall_column: str,
     transfer_summary: pd.DataFrame | None,
     transfer_note: str | None,
+    methods: list[str],
 ) -> None:
+    def _winner_label(group: pd.DataFrame, column: str) -> str:
+        best_value = float(group[column].max())
+        winners = ordered_method_names(
+            group[group[column] == best_value]["method"].astype(str).tolist()
+        )
+        if len(winners) == 1:
+            return f"`{winners[0]}`"
+        return "tie: " + ", ".join(f"`{method}`" for method in winners)
+
     winners: list[str] = []
     for entity_type in sorted(REQUIRED_ENTITY_TYPES):
-        group = by_type_summary[by_type_summary["entity_type"] == entity_type].set_index("method")
-        mrr_tfidf = float(group.loc["tfidf", "mrr_mean"])
-        mrr_bm25 = float(group.loc["bm25", "mrr_mean"])
-        recall_tfidf = float(group.loc["tfidf", f"{primary_recall_column}_mean"])
-        recall_bm25 = float(group.loc["bm25", f"{primary_recall_column}_mean"])
-
-        def _winner(left: float, right: float) -> str:
-            if left == right:
-                return "tie"
-            return "tfidf" if left > right else "bm25"
+        group = by_type_summary[by_type_summary["entity_type"] == entity_type].copy()
 
         winners.append(
-            f"- `{entity_type}`: MRR winner `{_winner(mrr_tfidf, mrr_bm25)}`, "
-            f"{primary_recall_column} winner `{_winner(recall_tfidf, recall_bm25)}`"
+            f"- `{entity_type}`: MRR winner {_winner_label(group, 'mrr_mean')}, "
+            f"{primary_recall_column} winner {_winner_label(group, f'{primary_recall_column}_mean')}"
         )
 
-    macro_rows = macro_summary[macro_summary["method"].isin(REQUIRED_METHODS)].set_index("method")
-    micro_rows = micro_summary[micro_summary["method"].isin(REQUIRED_METHODS)].set_index("method")
+    macro_rows = macro_summary[macro_summary["method"].isin(methods)].set_index("method")
+    micro_rows = micro_summary[micro_summary["method"].isin(methods)].set_index("method")
     reduction_snapshot = reduction_effectiveness[
         [
             "entity_type",
@@ -500,7 +563,7 @@ def _write_interpretation_scaffold(
         "## Coverage",
         "",
         "- Entity types covered: `class`, `predicate`, `instance`",
-        "- Methods compared: `tfidf`, `bm25`",
+        f"- Methods compared: {', '.join(f'`{method}`' for method in methods)}",
         "",
         "## Per-Type Winners",
         "",
@@ -508,20 +571,33 @@ def _write_interpretation_scaffold(
         "",
         "## Macro Summary",
         "",
-        f"- TF-IDF macro MRR: `{macro_rows.loc['tfidf', 'mrr_mean']:.6f}`",
-        f"- BM25 macro MRR: `{macro_rows.loc['bm25', 'mrr_mean']:.6f}`",
-        "",
-        "## Micro Summary",
-        "",
-        f"- TF-IDF micro MRR: `{micro_rows.loc['tfidf', 'mrr']:.6f}`",
-        f"- BM25 micro MRR: `{micro_rows.loc['bm25', 'mrr']:.6f}`",
-        "",
+    ]
+    for method in methods:
+        lines.append(f"- `{method}` macro MRR: `{macro_rows.loc[method, 'mrr_mean']:.6f}`")
+    lines.extend(
+        [
+            "",
+            "## Micro Summary",
+            "",
+        ]
+    )
+    for method in methods:
+        lines.append(f"- `{method}` micro MRR: `{micro_rows.loc[method, 'mrr']:.6f}`")
+    lines.extend(
+        [
+            "",
+        ]
+    )
+
+    lines.extend(
+        [
         "## Reduction vs Effectiveness Prompts",
         "",
         f"- Review `{primary_recall_column}` alongside `candidate_reduction_ratio` for each entity type.",
         "- Check whether the higher-reduction method also preserves MRR consistency across entity types.",
         "",
-    ]
+        ]
+    )
 
     if transfer_summary is not None:
         lines.extend(
@@ -569,13 +645,13 @@ def generate_kg_heldout_reporting(
     """Generate held-out KG reporting artifacts."""
     source_csv = _resolve_results_csv(results_csv_path)
     frame = pd.read_csv(source_csv)
-    validated, recall_columns = _validate_results_frame(frame)
+    validated, recall_columns, methods = _validate_results_frame(frame)
     heldout_datasets = set(validated["dataset"].unique())
 
-    by_type_summary = _build_by_type_summary(validated, recall_columns)
-    macro_summary = _build_macro_summary(by_type_summary, recall_columns)
-    micro_summary = _build_micro_summary(validated, recall_columns)
-    reduction_effectiveness = _build_reduction_effectiveness(validated, recall_columns)
+    by_type_summary = _build_by_type_summary(validated, recall_columns, methods)
+    macro_summary = _build_macro_summary(by_type_summary, recall_columns, methods)
+    micro_summary = _build_micro_summary(validated, recall_columns, methods)
+    reduction_effectiveness = _build_reduction_effectiveness(validated, recall_columns, methods)
 
     selected_settings_json, selected_settings_explicit = _resolve_selected_settings_json(
         selected_settings_path,
@@ -584,6 +660,7 @@ def generate_kg_heldout_reporting(
     transfer_payload, transfer_note = _load_selected_settings_payload(
         selected_settings_json,
         strict=selected_settings_explicit,
+        methods=methods,
     )
     transfer_summary = (
         _build_transfer_summary(transfer_payload, macro_summary, micro_summary)
@@ -621,6 +698,7 @@ def generate_kg_heldout_reporting(
         primary_recall_column=primary_recall_column,
         transfer_summary=transfer_summary,
         transfer_note=transfer_note,
+        methods=methods,
     )
 
     manifest_lines = [

--- a/src/analysis/model_comparison.py
+++ b/src/analysis/model_comparison.py
@@ -6,22 +6,30 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from src.analysis.plot_env import configure_plot_environment
-
-configure_plot_environment()
-
-import matplotlib
-matplotlib.use("Agg")
+from src.analysis import plot_env as _plot_env  # noqa: F401
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
 
+from src.method_registry import PRIMARY_COMPARISON_METHODS
+
 REQUIRED_COLUMNS = {"dataset", "track", "method", "mrr", "recall_at_10", "recall_at_50"}
-REQUIRED_METHODS = {"tfidf", "bm25"}
 
 
 class ComparisonValidationError(ValueError):
     """Raised when comparison input data is invalid."""
+
+
+def _coerce_count(value: object) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        return int(value)
+    raise TypeError(f"Unsupported count value: {value!r}")
 
 
 def _resolve_results_csv(results_csv_path: str | Path | None) -> Path:
@@ -40,20 +48,23 @@ def _resolve_results_csv(results_csv_path: str | Path | None) -> Path:
     return candidates[-1].resolve()
 
 
-def _validate_results_frame(frame: pd.DataFrame) -> None:
+def _validate_results_frame(frame: pd.DataFrame) -> pd.DataFrame:
     missing_columns = sorted(REQUIRED_COLUMNS - set(frame.columns))
     if missing_columns:
         raise ComparisonValidationError(
             "Missing required comparison column(s): " + ", ".join(missing_columns)
         )
 
-    methods = set(frame["method"].astype(str).unique())
-    missing_methods = sorted(REQUIRED_METHODS - methods)
+    validated = frame.copy()
+    validated["method"] = validated["method"].astype(str)
+    methods = set(validated["method"].unique())
+    missing_methods = sorted(set(PRIMARY_COMPARISON_METHODS) - methods)
     if missing_methods:
         raise ComparisonValidationError(
             "Comparison requires both methods. Missing: "
             + ", ".join(missing_methods)
         )
+    return validated[validated["method"].isin(PRIMARY_COMPARISON_METHODS)].copy()
 
 
 def _sort_frame(frame: pd.DataFrame) -> pd.DataFrame:
@@ -193,11 +204,12 @@ def _draw_best_mrr_dumbbell(best_frame: pd.DataFrame, output_base: Path) -> None
     fig_height = max(6, 0.35 * len(pivoted))
     fig, ax = plt.subplots(figsize=(12, fig_height), dpi=300)
 
-    y_positions = range(len(pivoted))
-    for idx, row in pivoted.iterrows():
+    y_positions = list(range(len(pivoted)))
+    for position, (_, row) in enumerate(pivoted.iterrows()):
+        line_y = [position, position]
         ax.plot(
             [row["tfidf"], row["bm25"]],
-            [idx, idx],
+            line_y,
             color="#9ca3af",
             linewidth=1.0,
             alpha=0.8,
@@ -269,9 +281,9 @@ def _write_interpretation_scaffold(
     def _winner_text(metric_row: Any) -> str:
         if metric_row is None:
             return "insufficient data"
-        if int(metric_row.tfidf_wins) == int(metric_row.bm25_wins):
+        if _coerce_count(metric_row.tfidf_wins) == _coerce_count(metric_row.bm25_wins):
             return "tie"
-        if int(metric_row.tfidf_wins) > int(metric_row.bm25_wins):
+        if _coerce_count(metric_row.tfidf_wins) > _coerce_count(metric_row.bm25_wins):
             return "TF-IDF"
         return "BM25"
 
@@ -285,7 +297,7 @@ def _write_interpretation_scaffold(
         if metric != "best_mrr":
             continue
         row = by_track_lookup[(track, metric)]
-        if int(row.bm25_wins) > int(row.tfidf_wins):
+        if _coerce_count(row.bm25_wins) > _coerce_count(row.tfidf_wins):
             bm25_mrr_tracks.append(track)
         else:
             tfidf_or_match_mrr_tracks.append(track)
@@ -320,23 +332,23 @@ def _write_interpretation_scaffold(
             (
                 "- Overall winner by MRR: "
                 f"{overall_mrr_winner} "
-                f"(tfidf_wins={int(mrr_row.tfidf_wins) if mrr_row else 0}, "
-                f"bm25_wins={int(mrr_row.bm25_wins) if mrr_row else 0}, "
-                f"ties={int(mrr_row.ties) if mrr_row else 0})."
+                f"(tfidf_wins={_coerce_count(mrr_row.tfidf_wins) if mrr_row else 0}, "
+                f"bm25_wins={_coerce_count(mrr_row.bm25_wins) if mrr_row else 0}, "
+                f"ties={_coerce_count(mrr_row.ties) if mrr_row else 0})."
             ),
             (
                 "- Overall winner by Recall@10: "
                 f"{overall_recall_winner} "
-                f"(tfidf_wins={int(recall_row.tfidf_wins) if recall_row else 0}, "
-                f"bm25_wins={int(recall_row.bm25_wins) if recall_row else 0}, "
-                f"ties={int(recall_row.ties) if recall_row else 0})."
+                f"(tfidf_wins={_coerce_count(recall_row.tfidf_wins) if recall_row else 0}, "
+                f"bm25_wins={_coerce_count(recall_row.bm25_wins) if recall_row else 0}, "
+                f"ties={_coerce_count(recall_row.ties) if recall_row else 0})."
             ),
             (
                 "- Overall winner by Recall@50: "
                 f"{overall_recall_50_winner} "
-                f"(tfidf_wins={int(recall_50_row.tfidf_wins) if recall_50_row else 0}, "
-                f"bm25_wins={int(recall_50_row.bm25_wins) if recall_50_row else 0}, "
-                f"ties={int(recall_50_row.ties) if recall_50_row else 0})."
+                f"(tfidf_wins={_coerce_count(recall_50_row.tfidf_wins) if recall_50_row else 0}, "
+                f"bm25_wins={_coerce_count(recall_50_row.bm25_wins) if recall_50_row else 0}, "
+                f"ties={_coerce_count(recall_50_row.ties) if recall_50_row else 0})."
             ),
             (
                 "- Tracks where BM25 clearly outperformed TF-IDF (best MRR view): "
@@ -370,7 +382,7 @@ def generate_model_comparison(
     """Generate TF-IDF vs BM25 model comparison outputs from an experiment CSV."""
     source_csv = _resolve_results_csv(results_csv_path)
     frame = pd.read_csv(source_csv)
-    _validate_results_frame(frame)
+    frame = _validate_results_frame(frame)
     if "hyperparameters" not in frame.columns:
         frame["hyperparameters"] = ""
 

--- a/src/analysis/plot_env.py
+++ b/src/analysis/plot_env.py
@@ -18,3 +18,7 @@ def configure_plot_environment() -> None:
 
     os.environ.setdefault("MPLCONFIGDIR", str(mpl_cache_dir))
     os.environ.setdefault("XDG_CACHE_HOME", str(xdg_cache_dir))
+    os.environ.setdefault("MPLBACKEND", "Agg")
+
+
+configure_plot_environment()

--- a/src/analysis/tfidf_sensitivity.py
+++ b/src/analysis/tfidf_sensitivity.py
@@ -7,12 +7,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from src.analysis.plot_env import configure_plot_environment
-
-configure_plot_environment()
-
-import matplotlib
-matplotlib.use("Agg")
+from src.analysis import plot_env as _plot_env  # noqa: F401
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns

--- a/src/experiments/experiment_runner.py
+++ b/src/experiments/experiment_runner.py
@@ -18,6 +18,7 @@ from tqdm import tqdm
 
 from src.config_loader import Bm25GridEntry, TfidfGridEntry, load_runtime_config
 from src.evaluation.metrics import compute_recall_at_ks_and_mrr
+from src.method_registry import ordered_method_names
 from src.preprocessing.text_preprocessor import preprocess_text, validate_nltk_assets
 from src.rdf_utils.alignment_parser import load_alignment_mappings
 from src.rdf_utils.label_extractor import extract_entity_label
@@ -199,10 +200,16 @@ def _build_model_runs(
     tfidf_grid: list[TfidfGridEntry], bm25_grid: list[Bm25GridEntry]
 ) -> list[ModelRunSpec]:
     model_runs: list[ModelRunSpec] = []
-    for params in tfidf_grid:
-        model_runs.append(_build_tfidf_model_run(params))
-    for params in bm25_grid:
-        model_runs.append(_build_bm25_model_run(params))
+    for method_name in ordered_method_names(("tfidf", "bm25")):
+        if method_name == "tfidf":
+            for params in tfidf_grid:
+                model_runs.append(_build_tfidf_model_run(params))
+            continue
+        if method_name == "bm25":
+            for params in bm25_grid:
+                model_runs.append(_build_bm25_model_run(params))
+            continue
+        raise ValueError(f"Unsupported registered development method: {method_name}")
     return model_runs
 
 

--- a/src/experiments/heldout_kg_runner.py
+++ b/src/experiments/heldout_kg_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+from dataclasses import dataclass
 from datetime import datetime
 import json
 import logging
@@ -17,6 +18,7 @@ from tqdm import tqdm
 from src.config_loader import load_runtime_config
 from src.evaluation.metrics import compute_recall_at_ks_and_mrr
 from src.experiments.experiment_runner import _load_store_with_fallback
+from src.method_registry import heldout_selected_method_names, ordered_method_names
 from src.preprocessing.text_preprocessor import preprocess_text, validate_nltk_assets
 from src.rdf_utils.alignment_parser import load_alignment_mappings
 from src.rdf_utils.entity_partitioning import (
@@ -66,6 +68,14 @@ class HeldoutKgResultRecord(TypedDict):
     recalls: dict[int, float]
     mrr: float
     runtime_seconds: float
+
+
+@dataclass(frozen=True)
+class HeldoutMethodRunSpec:
+    """Resolved held-out method execution configuration."""
+
+    method_name: str
+    hyperparameters: dict[str, object]
 
 
 def _get_git_short_sha() -> str:
@@ -131,7 +141,7 @@ def _load_selected_settings(selected_settings_path: Path) -> dict[str, dict[str,
     }
 
     resolved: dict[str, dict[str, object]] = {}
-    for method in ("tfidf", "bm25"):
+    for method in heldout_selected_method_names():
         entry = selected_settings.get(method)
         if not isinstance(entry, dict):
             raise HeldoutKgRunnerValidationError(
@@ -159,6 +169,67 @@ def _load_selected_settings(selected_settings_path: Path) -> dict[str, dict[str,
         json.dumps(resolved["bm25"], sort_keys=True, separators=(",", ":")),
     )
     return resolved
+
+
+def _build_heldout_method_runs(
+    frozen_settings: dict[str, dict[str, object]],
+) -> list[HeldoutMethodRunSpec]:
+    method_runs: list[HeldoutMethodRunSpec] = []
+    for method_name in ordered_method_names(frozen_settings.keys()):
+        method_runs.append(
+            HeldoutMethodRunSpec(
+                method_name=method_name,
+                hyperparameters=frozen_settings[method_name],
+            )
+        )
+    return method_runs
+
+
+def _predict_for_method(
+    *,
+    method_name: str,
+    hyperparameters: dict[str, object],
+    target_entities: list[str],
+    target_labels_preprocessed: list[str],
+    target_tokens: list[list[str]],
+    source_label_preprocessed_map: dict[str, str],
+    source_token_map: dict[str, list[str]],
+    eval_sources: list[str],
+    k_max: int,
+) -> dict[str, list[tuple[str, float]]]:
+    if method_name == "tfidf":
+        retriever = TfidfRetriever(
+            ngram_range=tuple(cast(list[int], hyperparameters["ngram_range"])),
+            min_df=cast(int | float, hyperparameters["min_df"]),
+            max_df=cast(int | float, hyperparameters["max_df"]),
+            sublinear_tf=cast(bool, hyperparameters["sublinear_tf"]),
+        )
+        retriever.fit_preprocessed(target_entities, target_labels_preprocessed)
+        return {
+            source_id: retriever.retrieve_preprocessed(
+                source_label_preprocessed_map[source_id],
+                k=k_max,
+            )
+            for source_id in eval_sources
+        }
+
+    if method_name == "bm25":
+        retriever = Bm25Retriever(
+            k1=float(cast(int | float, hyperparameters["k1"])),
+            b=float(cast(int | float, hyperparameters["b"])),
+        )
+        retriever.fit_tokenized(target_entities, target_tokens)
+        return {
+            source_id: retriever.retrieve_tokenized(
+                source_token_map[source_id],
+                k=k_max,
+            )
+            for source_id in eval_sources
+        }
+
+    raise HeldoutKgRunnerValidationError(
+        f"Unsupported registered held-out method '{method_name}'."
+    )
 
 
 def _build_labels(store, entity_ids: list[str]) -> list[str]:
@@ -264,6 +335,7 @@ def run_heldout_kg_experiments(
     runtime_config = load_runtime_config(config_path=config_path, require_heldout=True)
     selected_settings_json = _resolve_selected_settings_json(selected_settings_path)
     frozen_settings = _load_selected_settings(selected_settings_json)
+    method_runs = _build_heldout_method_runs(frozen_settings)
     datasets = runtime_config.heldout_datasets
     if not datasets:
         raise HeldoutKgRunnerValidationError(
@@ -349,8 +421,9 @@ def run_heldout_kg_experiments(
                 candidate_reduction_ratio,
             )
 
-            for method_name in ("tfidf", "bm25"):
-                hyperparameters = frozen_settings[method_name]
+            for method_run in method_runs:
+                method_name = method_run.method_name
+                hyperparameters = method_run.hyperparameters
                 run_start = time.perf_counter()
                 logger.info(
                     "Running held-out dataset='%s' entity_type=%s method=%s hyperparameters=%s",
@@ -359,34 +432,17 @@ def run_heldout_kg_experiments(
                     method_name,
                     hyperparameters,
                 )
-                if method_name == "tfidf":
-                    retriever = TfidfRetriever(
-                        ngram_range=tuple(cast(list[int], hyperparameters["ngram_range"])),
-                        min_df=cast(int | float, hyperparameters["min_df"]),
-                        max_df=cast(int | float, hyperparameters["max_df"]),
-                        sublinear_tf=cast(bool, hyperparameters["sublinear_tf"]),
-                    )
-                    retriever.fit_preprocessed(target_entities, target_labels_preprocessed)
-                    predictions = {
-                        source_id: retriever.retrieve_preprocessed(
-                            source_label_preprocessed_map[source_id],
-                            k=k_max,
-                        )
-                        for source_id in eval_sources
-                    }
-                else:
-                    retriever = Bm25Retriever(
-                        k1=float(cast(int | float, hyperparameters["k1"])),
-                        b=float(cast(int | float, hyperparameters["b"])),
-                    )
-                    retriever.fit_tokenized(target_entities, target_tokens)
-                    predictions = {
-                        source_id: retriever.retrieve_tokenized(
-                            source_token_map[source_id],
-                            k=k_max,
-                        )
-                        for source_id in eval_sources
-                    }
+                predictions = _predict_for_method(
+                    method_name=method_name,
+                    hyperparameters=hyperparameters,
+                    target_entities=target_entities,
+                    target_labels_preprocessed=target_labels_preprocessed,
+                    target_tokens=target_tokens,
+                    source_label_preprocessed_map=source_label_preprocessed_map,
+                    source_token_map=source_token_map,
+                    eval_sources=eval_sources,
+                    k_max=k_max,
+                )
 
                 raw_recalls, mrr = compute_recall_at_ks_and_mrr(
                     predictions, gold, evaluation_ks

--- a/src/method_registry.py
+++ b/src/method_registry.py
@@ -1,0 +1,66 @@
+"""Shared method registry metadata for candidate-generation workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class MethodDescriptor:
+    """Static metadata about a supported candidate-generation method."""
+
+    name: str
+    tunable: bool
+    fixed: bool
+    supports_development: bool = True
+    supports_heldout: bool = True
+    selected_settings_required: bool = False
+
+
+PRIMARY_COMPARISON_METHODS: tuple[str, str] = ("tfidf", "bm25")
+
+REGISTERED_METHODS: tuple[MethodDescriptor, ...] = (
+    MethodDescriptor(
+        name="tfidf",
+        tunable=True,
+        fixed=False,
+        selected_settings_required=True,
+    ),
+    MethodDescriptor(
+        name="bm25",
+        tunable=True,
+        fixed=False,
+        selected_settings_required=True,
+    ),
+)
+
+REGISTERED_METHODS_BY_NAME = {descriptor.name: descriptor for descriptor in REGISTERED_METHODS}
+
+
+def registered_method_names() -> list[str]:
+    return [descriptor.name for descriptor in REGISTERED_METHODS]
+
+
+def tunable_method_names() -> list[str]:
+    return [descriptor.name for descriptor in REGISTERED_METHODS if descriptor.tunable]
+
+
+def heldout_selected_method_names() -> list[str]:
+    return [
+        descriptor.name
+        for descriptor in REGISTERED_METHODS
+        if descriptor.supports_heldout and descriptor.selected_settings_required
+    ]
+
+
+def supports_primary_comparison(method_names: Iterable[str]) -> bool:
+    observed = {str(name) for name in method_names}
+    return all(method in observed for method in PRIMARY_COMPARISON_METHODS)
+
+
+def ordered_method_names(method_names: Iterable[str]) -> list[str]:
+    deduplicated = list(dict.fromkeys(str(name) for name in method_names))
+    known = [name for name in registered_method_names() if name in deduplicated]
+    unknown = sorted(name for name in deduplicated if name not in REGISTERED_METHODS_BY_NAME)
+    return known + unknown

--- a/tests/test_heldout_selection.py
+++ b/tests/test_heldout_selection.py
@@ -246,6 +246,7 @@ class HeldoutSelectionTests(unittest.TestCase):
             payload = json.loads(
                 Path(artifacts["heldout_selected_settings"]).read_text(encoding="utf-8")
             )
+            self.assertEqual(payload["selected_method_names"], ["tfidf", "bm25"])
             self.assertEqual(set(payload["selected_settings"].keys()), {"tfidf", "bm25"})
             self.assertEqual(payload["policy"]["metric"], "mrr")
             self.assertEqual(payload["policy"]["lambda"], 0.5)

--- a/tests/test_kg_heldout_reporting.py
+++ b/tests/test_kg_heldout_reporting.py
@@ -12,7 +12,7 @@ from src.analysis.kg_heldout_reporting import (
 
 
 class KgHeldoutReportingTests(unittest.TestCase):
-    def _write_results_csv(self, path: Path) -> None:
+    def _write_results_csv(self, path: Path, *, include_extra_method: bool = False) -> None:
         rows = [
             {
                 "track": "kg",
@@ -208,6 +208,108 @@ class KgHeldoutReportingTests(unittest.TestCase):
             },
         ]
 
+        if include_extra_method:
+            rows.extend(
+                [
+                    {
+                        "track": "kg",
+                        "version": "heldout-v1",
+                        "dataset": "d1",
+                        "entity_type": "class",
+                        "method": "chargram",
+                        "hyperparameters": '{"cfg":"chargram"}',
+                        "gold_count": 10,
+                        "target_pool_size": 100,
+                        "retained_candidate_size": 50,
+                        "candidate_reduction_ratio": 0.50,
+                        "recall_at_1": 0.65,
+                        "recall_at_50": 0.91,
+                        "mrr": 0.82,
+                        "runtime_seconds": 0.08,
+                    },
+                    {
+                        "track": "kg",
+                        "version": "heldout-v1",
+                        "dataset": "d2",
+                        "entity_type": "class",
+                        "method": "chargram",
+                        "hyperparameters": '{"cfg":"chargram"}',
+                        "gold_count": 1,
+                        "target_pool_size": 80,
+                        "retained_candidate_size": 40,
+                        "candidate_reduction_ratio": 0.50,
+                        "recall_at_1": 0.45,
+                        "recall_at_50": 0.75,
+                        "mrr": 0.62,
+                        "runtime_seconds": 0.07,
+                    },
+                    {
+                        "track": "kg",
+                        "version": "heldout-v1",
+                        "dataset": "d1",
+                        "entity_type": "predicate",
+                        "method": "chargram",
+                        "hyperparameters": '{"cfg":"chargram"}',
+                        "gold_count": 1,
+                        "target_pool_size": 20,
+                        "retained_candidate_size": 5,
+                        "candidate_reduction_ratio": 0.75,
+                        "recall_at_1": 0.25,
+                        "recall_at_50": 0.52,
+                        "mrr": 0.45,
+                        "runtime_seconds": 0.05,
+                    },
+                    {
+                        "track": "kg",
+                        "version": "heldout-v1",
+                        "dataset": "d2",
+                        "entity_type": "predicate",
+                        "method": "chargram",
+                        "hyperparameters": '{"cfg":"chargram"}',
+                        "gold_count": 1,
+                        "target_pool_size": 10,
+                        "retained_candidate_size": 4,
+                        "candidate_reduction_ratio": 0.60,
+                        "recall_at_1": 0.25,
+                        "recall_at_50": 0.68,
+                        "mrr": 0.57,
+                        "runtime_seconds": 0.05,
+                    },
+                    {
+                        "track": "kg",
+                        "version": "heldout-v1",
+                        "dataset": "d1",
+                        "entity_type": "instance",
+                        "method": "chargram",
+                        "hyperparameters": '{"cfg":"chargram"}',
+                        "gold_count": 1,
+                        "target_pool_size": 200,
+                        "retained_candidate_size": 50,
+                        "candidate_reduction_ratio": 0.75,
+                        "recall_at_1": 0.12,
+                        "recall_at_50": 0.38,
+                        "mrr": 0.31,
+                        "runtime_seconds": 0.09,
+                    },
+                    {
+                        "track": "kg",
+                        "version": "heldout-v1",
+                        "dataset": "d2",
+                        "entity_type": "instance",
+                        "method": "chargram",
+                        "hyperparameters": '{"cfg":"chargram"}',
+                        "gold_count": 20,
+                        "target_pool_size": 150,
+                        "retained_candidate_size": 50,
+                        "candidate_reduction_ratio": 2.0 / 3.0,
+                        "recall_at_1": 0.42,
+                        "recall_at_50": 0.62,
+                        "mrr": 0.52,
+                        "runtime_seconds": 0.11,
+                    },
+                ]
+            )
+
         with path.open("w", encoding="utf-8", newline="") as csv_file:
             writer = csv.DictWriter(csv_file, fieldnames=list(rows[0].keys()))
             writer.writeheader()
@@ -324,6 +426,41 @@ class KgHeldoutReportingTests(unittest.TestCase):
             self.assertAlmostEqual(float(transfer_tfidf["development_mu"]), 0.88)
             self.assertAlmostEqual(float(transfer_tfidf["heldout_macro_mrr"]), (0.8 + 0.5 + 0.4) / 3.0)
             self.assertAlmostEqual(float(transfer_tfidf["heldout_micro_mrr"]), 21.0 / 34.0)
+
+    def test_method_agnostic_summaries_allow_extra_methods(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            results_csv = tmp / "heldout_result_fixture.csv"
+            selected_json = tmp / "heldout_selected_settings.json"
+            self._write_results_csv(results_csv, include_extra_method=True)
+            self._write_selected_settings(selected_json)
+
+            artifacts = generate_kg_heldout_reporting(
+                results_csv_path=results_csv,
+                output_dir=tmp / "comparisons",
+                selected_settings_path=selected_json,
+            )
+
+            with Path(artifacts["kg_heldout_by_type_summary"]).open(encoding="utf-8") as csv_file:
+                by_type_rows = list(csv.DictReader(csv_file))
+            self.assertIn("chargram", {row["method"] for row in by_type_rows})
+
+            with Path(artifacts["kg_heldout_macro_summary"]).open(encoding="utf-8") as csv_file:
+                macro_rows = list(csv.DictReader(csv_file))
+            self.assertIn("chargram", {row["method"] for row in macro_rows})
+            self.assertIn("delta_tfidf_minus_bm25", {row["method"] for row in macro_rows})
+
+            with Path(artifacts["kg_heldout_micro_summary"]).open(encoding="utf-8") as csv_file:
+                micro_rows = list(csv.DictReader(csv_file))
+            self.assertIn("chargram", {row["method"] for row in micro_rows})
+
+            with Path(artifacts["kg_heldout_reduction_effectiveness"]).open(
+                encoding="utf-8"
+            ) as csv_file:
+                reduction_rows = list(csv.DictReader(csv_file))
+            chargram_row = next(row for row in reduction_rows if row["method"] == "chargram")
+            self.assertEqual(chargram_row["other_method"], "")
+            self.assertEqual(chargram_row["mrr_delta_vs_other_method"], "")
 
     def test_reduction_effectiveness_includes_per_pair_deltas(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_model_comparison.py
+++ b/tests/test_model_comparison.py
@@ -11,7 +11,7 @@ from src.analysis.model_comparison import (
 
 
 class ModelComparisonTests(unittest.TestCase):
-    def _write_results_csv(self, path: Path) -> None:
+    def _write_results_csv(self, path: Path, *, include_extra_method: bool = False) -> None:
         rows = [
             # biodiv dataset: best MRR and best Recall@10 come from different rows.
             {
@@ -107,6 +107,29 @@ class ModelComparisonTests(unittest.TestCase):
                 "recall_at_50": 0.99,
             },
         ]
+        if include_extra_method:
+            rows.extend(
+                [
+                    {
+                        "track": "biodiv",
+                        "dataset": "d1",
+                        "method": "chargram",
+                        "hyperparameters": '{"cfg":"x"}',
+                        "mrr": 0.50,
+                        "recall_at_10": 0.60,
+                        "recall_at_50": 0.70,
+                    },
+                    {
+                        "track": "conference",
+                        "dataset": "d2",
+                        "method": "chargram",
+                        "hyperparameters": '{"cfg":"y"}',
+                        "mrr": 0.52,
+                        "recall_at_10": 0.62,
+                        "recall_at_50": 0.72,
+                    },
+                ]
+            )
 
         fieldnames = [
             "track",
@@ -188,6 +211,18 @@ class ModelComparisonTests(unittest.TestCase):
             self.assertAlmostEqual(float(agg_target["mrr_median"]), 0.835)
             self.assertAlmostEqual(float(agg_target["recall_at_10_mean"]), 0.90)
             self.assertAlmostEqual(float(agg_target["recall_at_50_mean"]), 0.975)
+
+    def test_ignores_extra_methods_outside_primary_comparison_pair(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            source_csv = tmp / "result_fixture.csv"
+            self._write_results_csv(source_csv, include_extra_method=True)
+
+            artifacts = generate_model_comparison(source_csv, output_dir=tmp / "comparisons")
+
+            with Path(artifacts["best_of_grid_summary"]).open(encoding="utf-8") as best_file:
+                best_rows = list(csv.DictReader(best_file))
+            self.assertEqual({row["method"] for row in best_rows}, {"tfidf", "bm25"})
 
     def test_win_loss_tie_counts(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- add a shared method registry abstraction so evaluation workflows are no longer hard-coded to a TF-IDF/BM25 pair
- generalize development execution, held-out execution, and held-out reporting for method-capable iteration while keeping frozen selection scoped to TF-IDF and BM25
- preserve backward-compatible TF-IDF/BM25 comparison outputs and add regression coverage for extra methods in reporting and comparison flows

## Testing
- ./venv/bin/python3.12 -m unittest tests.test_experiment_runner tests.test_model_comparison tests.test_heldout_selection tests.test_heldout_kg_runner tests.test_kg_heldout_reporting tests.test_main_cli -v

Closes #43
