### PR TITLE
feat: add exact-match candidate generation baseline (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ dataset config
   -> class filtering (owl:Class)
   -> label extraction
   -> text preprocessing
-  -> lexical retrieval (TF-IDF / BM25)
+  -> lexical retrieval (TF-IDF / BM25 / exact_match)
   -> metric computation (Recall@k, MRR)
   -> CSV result storage
 ```
 
 Where methods fit:
 
-- **TF-IDF** and **BM25** are the candidate retrievers.
+- **TF-IDF**, **BM25**, and **exact_match** are the candidate retrievers.
 - **Recall@k** and **MRR** are computed on ranked candidate lists produced per source entity.
 
 Mathematical definitions (LaTeX-ready):
@@ -514,8 +514,8 @@ Artifact handoff:
 
 ## Held-Out KG Runner
 
-Use the dedicated held-out KG runner to evaluate frozen TF-IDF and BM25 settings by
-entity type across `heldout_datasets`.
+Use the dedicated held-out KG runner to evaluate frozen TF-IDF and BM25 settings, plus
+the fixed `exact_match` floor baseline, by entity type across `heldout_datasets`.
 
 With latest selected-settings artifact (auto-detected):
 
@@ -715,6 +715,28 @@ retriever.fit(
 )
 results = retriever.retrieve("plant height value", k=2)
 ```
+
+## Exact-Match Baseline
+
+Use `ExactMatchRetriever` from `src/retrieval/exact_match_retriever.py` for the fixed
+normalized exact-match baseline.
+
+Normalization policy:
+
+- lowercase
+- split camel case
+- normalize `-`, `_`, and `/` to spaces
+- strip punctuation
+- collapse repeated whitespace
+- keep stopwords
+
+Behavior:
+
+- candidates are returned only when the normalized source label exactly matches the
+  normalized target label
+- multiple matches are ranked deterministically by target URI
+- the baseline uses a fixed configuration and does not participate in held-out
+  hyperparameter selection
 
 ## BM25 Retrieval
 

--- a/src/experiments/experiment_runner.py
+++ b/src/experiments/experiment_runner.py
@@ -18,11 +18,12 @@ from tqdm import tqdm
 
 from src.config_loader import Bm25GridEntry, TfidfGridEntry, load_runtime_config
 from src.evaluation.metrics import compute_recall_at_ks_and_mrr
-from src.method_registry import ordered_method_names
+from src.method_registry import development_method_names, fixed_method_hyperparameters
 from src.preprocessing.text_preprocessor import preprocess_text, validate_nltk_assets
 from src.rdf_utils.alignment_parser import load_alignment_mappings
 from src.rdf_utils.label_extractor import extract_entity_label
 from src.retrieval.bm25_retriever import Bm25Retriever
+from src.retrieval.exact_match_retriever import ExactMatchRetriever
 from src.retrieval.tfidf_retriever import TfidfRetriever
 
 RDF_TYPE = NamedNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
@@ -196,11 +197,19 @@ def _build_bm25_model_run(params: Bm25GridEntry) -> ModelRunSpec:
     )
 
 
+def _build_exact_match_model_run() -> ModelRunSpec:
+    return ModelRunSpec(
+        model_name="exact_match",
+        hyperparameters=fixed_method_hyperparameters("exact_match"),
+        retriever=ExactMatchRetriever(),
+    )
+
+
 def _build_model_runs(
     tfidf_grid: list[TfidfGridEntry], bm25_grid: list[Bm25GridEntry]
 ) -> list[ModelRunSpec]:
     model_runs: list[ModelRunSpec] = []
-    for method_name in ordered_method_names(("tfidf", "bm25")):
+    for method_name in development_method_names():
         if method_name == "tfidf":
             for params in tfidf_grid:
                 model_runs.append(_build_tfidf_model_run(params))
@@ -208,6 +217,9 @@ def _build_model_runs(
         if method_name == "bm25":
             for params in bm25_grid:
                 model_runs.append(_build_bm25_model_run(params))
+            continue
+        if method_name == "exact_match":
+            model_runs.append(_build_exact_match_model_run())
             continue
         raise ValueError(f"Unsupported registered development method: {method_name}")
     return model_runs
@@ -328,6 +340,7 @@ def run_experiments(
             target_labels = _build_labels(target_store, target_entities)
             eval_sources = sorted(gold_filtered.keys())
             source_labels = _build_labels(source_store, eval_sources)
+            source_label_map = dict(zip(eval_sources, source_labels, strict=True))
 
             target_tokens, target_labels_preprocessed = _preprocess_labels(target_labels)
             source_tokens, source_labels_preprocessed = _preprocess_labels(source_labels)
@@ -369,6 +382,9 @@ def run_experiments(
                     elif run.model_name == "bm25":
                         bm25_retriever = cast(Bm25Retriever, run.retriever)
                         bm25_retriever.fit_tokenized(target_entities, target_tokens)
+                    elif run.model_name == "exact_match":
+                        exact_match_retriever = cast(ExactMatchRetriever, run.retriever)
+                        exact_match_retriever.fit(target_entities, target_labels)
                     else:
                         raise ValueError(f"Unsupported model type: {run.model_name}")
 
@@ -385,10 +401,15 @@ def run_experiments(
                             predictions[source_id] = tfidf_retriever.retrieve_preprocessed(
                                 source_label_preprocessed_map[source_id], k=k_max
                             )
-                        else:
+                        elif run.model_name == "bm25":
                             bm25_retriever = cast(Bm25Retriever, run.retriever)
                             predictions[source_id] = bm25_retriever.retrieve_tokenized(
                                 source_token_map[source_id], k=k_max
+                            )
+                        else:
+                            exact_match_retriever = cast(ExactMatchRetriever, run.retriever)
+                            predictions[source_id] = exact_match_retriever.retrieve(
+                                source_label_map[source_id], k=k_max
                             )
 
                     raw_recalls, mrr = compute_recall_at_ks_and_mrr(

--- a/src/experiments/heldout_kg_runner.py
+++ b/src/experiments/heldout_kg_runner.py
@@ -18,7 +18,12 @@ from tqdm import tqdm
 from src.config_loader import load_runtime_config
 from src.evaluation.metrics import compute_recall_at_ks_and_mrr
 from src.experiments.experiment_runner import _load_store_with_fallback
-from src.method_registry import heldout_selected_method_names, ordered_method_names
+from src.method_registry import (
+    fixed_method_hyperparameters,
+    fixed_method_names,
+    heldout_selected_method_names,
+    ordered_method_names,
+)
 from src.preprocessing.text_preprocessor import preprocess_text, validate_nltk_assets
 from src.rdf_utils.alignment_parser import load_alignment_mappings
 from src.rdf_utils.entity_partitioning import (
@@ -30,6 +35,7 @@ from src.rdf_utils.entity_partitioning import (
 )
 from src.rdf_utils.label_extractor import extract_entity_label
 from src.retrieval.bm25_retriever import Bm25Retriever
+from src.retrieval.exact_match_retriever import ExactMatchRetriever
 from src.retrieval.tfidf_retriever import TfidfRetriever
 
 logger = logging.getLogger(__name__)
@@ -175,14 +181,36 @@ def _build_heldout_method_runs(
     frozen_settings: dict[str, dict[str, object]],
 ) -> list[HeldoutMethodRunSpec]:
     method_runs: list[HeldoutMethodRunSpec] = []
-    for method_name in ordered_method_names(frozen_settings.keys()):
+    runtime_methods = list(frozen_settings.keys()) + fixed_method_names(heldout=True)
+    for method_name in ordered_method_names(runtime_methods):
+        if method_name in frozen_settings:
+            hyperparameters = frozen_settings[method_name]
+        else:
+            hyperparameters = fixed_method_hyperparameters(method_name)
         method_runs.append(
             HeldoutMethodRunSpec(
                 method_name=method_name,
-                hyperparameters=frozen_settings[method_name],
+                hyperparameters=hyperparameters,
             )
         )
     return method_runs
+
+
+def _coerce_tfidf_ngram_range(value: object) -> tuple[int, int]:
+    if not isinstance(value, list) or len(value) != 2:
+        raise HeldoutKgRunnerValidationError(
+            "Selected settings for method 'tfidf' must include a two-item ngram_range list."
+        )
+    first, second = value
+    if not isinstance(first, int) or isinstance(first, bool):
+        raise HeldoutKgRunnerValidationError(
+            "Selected settings for method 'tfidf' must include an integer ngram_range[0]."
+        )
+    if not isinstance(second, int) or isinstance(second, bool):
+        raise HeldoutKgRunnerValidationError(
+            "Selected settings for method 'tfidf' must include an integer ngram_range[1]."
+        )
+    return (first, second)
 
 
 def _predict_for_method(
@@ -190,8 +218,10 @@ def _predict_for_method(
     method_name: str,
     hyperparameters: dict[str, object],
     target_entities: list[str],
+    target_labels: list[str],
     target_labels_preprocessed: list[str],
     target_tokens: list[list[str]],
+    source_label_map: dict[str, str],
     source_label_preprocessed_map: dict[str, str],
     source_token_map: dict[str, list[str]],
     eval_sources: list[str],
@@ -199,7 +229,7 @@ def _predict_for_method(
 ) -> dict[str, list[tuple[str, float]]]:
     if method_name == "tfidf":
         retriever = TfidfRetriever(
-            ngram_range=tuple(cast(list[int], hyperparameters["ngram_range"])),
+            ngram_range=_coerce_tfidf_ngram_range(hyperparameters["ngram_range"]),
             min_df=cast(int | float, hyperparameters["min_df"]),
             max_df=cast(int | float, hyperparameters["max_df"]),
             sublinear_tf=cast(bool, hyperparameters["sublinear_tf"]),
@@ -222,6 +252,17 @@ def _predict_for_method(
         return {
             source_id: retriever.retrieve_tokenized(
                 source_token_map[source_id],
+                k=k_max,
+            )
+            for source_id in eval_sources
+        }
+
+    if method_name == "exact_match":
+        retriever = ExactMatchRetriever()
+        retriever.fit(target_entities, target_labels)
+        return {
+            source_id: retriever.retrieve(
+                source_label_map[source_id],
                 k=k_max,
             )
             for source_id in eval_sources
@@ -399,6 +440,7 @@ def run_heldout_kg_experiments(
             eval_sources = sorted(gold.keys())
             target_labels = _build_labels(target_store, target_entities)
             source_labels = _build_labels(source_store, eval_sources)
+            source_label_map = dict(zip(eval_sources, source_labels, strict=True))
             target_tokens, target_labels_preprocessed = _preprocess_labels(target_labels)
             source_tokens, source_labels_preprocessed = _preprocess_labels(source_labels)
             source_label_preprocessed_map = dict(
@@ -436,8 +478,10 @@ def run_heldout_kg_experiments(
                     method_name=method_name,
                     hyperparameters=hyperparameters,
                     target_entities=target_entities,
+                    target_labels=target_labels,
                     target_labels_preprocessed=target_labels_preprocessed,
                     target_tokens=target_tokens,
+                    source_label_map=source_label_map,
                     source_label_preprocessed_map=source_label_preprocessed_map,
                     source_token_map=source_token_map,
                     eval_sources=eval_sources,

--- a/src/method_registry.py
+++ b/src/method_registry.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable
 
+from src.preprocessing.exact_match_normalizer import (
+    EXACT_MATCH_NORMALIZATION_VERSION,
+)
+
 
 @dataclass(frozen=True)
 class MethodDescriptor:
@@ -16,6 +20,7 @@ class MethodDescriptor:
     supports_development: bool = True
     supports_heldout: bool = True
     selected_settings_required: bool = False
+    fixed_hyperparameters: dict[str, object] | None = None
 
 
 PRIMARY_COMPARISON_METHODS: tuple[str, str] = ("tfidf", "bm25")
@@ -33,6 +38,13 @@ REGISTERED_METHODS: tuple[MethodDescriptor, ...] = (
         fixed=False,
         selected_settings_required=True,
     ),
+    MethodDescriptor(
+        name="exact_match",
+        tunable=False,
+        fixed=True,
+        selected_settings_required=False,
+        fixed_hyperparameters={"normalization": EXACT_MATCH_NORMALIZATION_VERSION},
+    ),
 )
 
 REGISTERED_METHODS_BY_NAME = {descriptor.name: descriptor for descriptor in REGISTERED_METHODS}
@@ -46,12 +58,40 @@ def tunable_method_names() -> list[str]:
     return [descriptor.name for descriptor in REGISTERED_METHODS if descriptor.tunable]
 
 
+def development_method_names() -> list[str]:
+    return [descriptor.name for descriptor in REGISTERED_METHODS if descriptor.supports_development]
+
+
+def heldout_method_names() -> list[str]:
+    return [descriptor.name for descriptor in REGISTERED_METHODS if descriptor.supports_heldout]
+
+
 def heldout_selected_method_names() -> list[str]:
     return [
         descriptor.name
         for descriptor in REGISTERED_METHODS
         if descriptor.supports_heldout and descriptor.selected_settings_required
     ]
+
+
+def fixed_method_names(*, development: bool = False, heldout: bool = False) -> list[str]:
+    names: list[str] = []
+    for descriptor in REGISTERED_METHODS:
+        if not descriptor.fixed:
+            continue
+        if development and not descriptor.supports_development:
+            continue
+        if heldout and not descriptor.supports_heldout:
+            continue
+        names.append(descriptor.name)
+    return names
+
+
+def fixed_method_hyperparameters(method_name: str) -> dict[str, object]:
+    descriptor = REGISTERED_METHODS_BY_NAME.get(str(method_name))
+    if descriptor is None or descriptor.fixed_hyperparameters is None:
+        raise KeyError(f"No fixed hyperparameters registered for method '{method_name}'.")
+    return dict(descriptor.fixed_hyperparameters)
 
 
 def supports_primary_comparison(method_names: Iterable[str]) -> bool:

--- a/src/preprocessing/exact_match_normalizer.py
+++ b/src/preprocessing/exact_match_normalizer.py
@@ -1,0 +1,32 @@
+"""Normalization utilities for the exact-match lexical baseline."""
+
+from __future__ import annotations
+
+import re
+import string
+
+EXACT_MATCH_NORMALIZATION_VERSION = "light_v1"
+
+
+def _split_camel_case(text: str) -> str:
+    return re.sub(r"([a-z0-9])([A-Z][a-z])", r"\1 \2", text)
+
+
+def normalize_exact_match_text(text: str) -> str:
+    """Apply conservative normalization for the exact-match baseline.
+
+    Policy:
+    - lowercase
+    - split camel case
+    - normalize '-', '_' and '/' to spaces
+    - strip punctuation
+    - collapse repeated whitespace
+    - preserve stopwords
+    """
+
+    camel_split = _split_camel_case(text).lower()
+    separator_normalized = re.sub(r"[-_/]+", " ", camel_split)
+    punctuation_as_space = separator_normalized.translate(
+        str.maketrans({char: " " for char in string.punctuation})
+    )
+    return re.sub(r"\s+", " ", punctuation_as_space).strip()

--- a/src/retrieval/exact_match_retriever.py
+++ b/src/retrieval/exact_match_retriever.py
@@ -1,0 +1,46 @@
+"""Exact normalized string-match retrieval baseline."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from src.preprocessing.exact_match_normalizer import normalize_exact_match_text
+
+
+class ExactMatchRetriever:
+    """Retrieve candidates whose normalized labels match the normalized query exactly."""
+
+    def __init__(self) -> None:
+        self._index: dict[str, list[str]] = {}
+        self._is_fitted = False
+
+    def fit(self, entity_ids: list[str], labels: list[str]) -> None:
+        """Build a deterministic exact-match index over raw labels."""
+        if len(entity_ids) != len(labels):
+            raise ValueError("entity_ids and labels must have the same length.")
+        if not entity_ids:
+            raise ValueError("entity_ids and labels must not be empty.")
+
+        grouped: dict[str, list[str]] = defaultdict(list)
+        for entity_id, label in zip(entity_ids, labels, strict=True):
+            grouped[normalize_exact_match_text(label)].append(entity_id)
+
+        self._index = {
+            normalized: sorted(entity_group)
+            for normalized, entity_group in grouped.items()
+        }
+        self._is_fitted = True
+
+    def retrieve(self, query_text: str, k: int) -> list[tuple[str, float]]:
+        """Return exact normalized matches, ranked deterministically by target URI."""
+        if not self._is_fitted:
+            raise ValueError("Retriever is not fitted. Call fit(...) before retrieve(...).")
+        if k <= 0:
+            raise ValueError("k must be a positive integer.")
+
+        normalized_query = normalize_exact_match_text(query_text)
+        if normalized_query not in self._index:
+            return []
+
+        ranked_entity_ids = self._index[normalized_query][:k]
+        return [(entity_id, 1.0) for entity_id in ranked_entity_ids]

--- a/tests/test_exact_match_retriever.py
+++ b/tests/test_exact_match_retriever.py
@@ -1,0 +1,48 @@
+import unittest
+
+from src.preprocessing.exact_match_normalizer import normalize_exact_match_text
+from src.retrieval.exact_match_retriever import ExactMatchRetriever
+
+
+class ExactMatchRetrieverTests(unittest.TestCase):
+    def test_normalization_is_conservative_and_preserves_stopwords(self) -> None:
+        self.assertEqual(normalize_exact_match_text("PlantHeight"), "plant height")
+        self.assertEqual(
+            normalize_exact_match_text("Plant-Height/Value_Test"),
+            "plant height value test",
+        )
+        self.assertEqual(normalize_exact_match_text("The Hero"), "the hero")
+
+    def test_retrieves_normalized_exact_match(self) -> None:
+        retriever = ExactMatchRetriever()
+        retriever.fit(
+            ["urn:target:1", "urn:target:2"],
+            ["plant height", "leaf color"],
+        )
+
+        self.assertEqual(
+            retriever.retrieve("PlantHeight", k=5),
+            [("urn:target:1", 1.0)],
+        )
+
+    def test_multiple_matches_are_ranked_by_target_uri(self) -> None:
+        retriever = ExactMatchRetriever()
+        retriever.fit(
+            ["urn:target:z", "urn:target:a", "urn:target:m"],
+            ["Thor", "thor", "Loki"],
+        )
+
+        self.assertEqual(
+            retriever.retrieve("THOR", k=5),
+            [("urn:target:a", 1.0), ("urn:target:z", 1.0)],
+        )
+
+    def test_empty_match_returns_no_candidates(self) -> None:
+        retriever = ExactMatchRetriever()
+        retriever.fit(["urn:target:1"], ["plant height"])
+
+        self.assertEqual(retriever.retrieve("root length", k=5), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -173,10 +173,10 @@ heldout:
             self.assertTrue(output_csv_path.exists())
 
         self.assertTrue(results)
-        self.assertEqual(len(results), 4)  # 2 TF-IDF configs + 2 BM25 configs
+        self.assertEqual(len(results), 5)  # 2 TF-IDF configs + 2 BM25 configs + 1 exact match
 
         models = {row["model"] for row in results}
-        self.assertEqual(models, {"tfidf", "bm25"})
+        self.assertEqual(models, {"tfidf", "bm25", "exact_match"})
 
         for row in results:
             for key in (
@@ -251,7 +251,7 @@ heldout:
         self.assertEqual(len(rows), len(results))
         for row in rows:
             self.assertEqual(row["dataset"], "fixture_dataset")
-            self.assertIn(row["method"], {"tfidf", "bm25"})
+            self.assertIn(row["method"], {"tfidf", "bm25", "exact_match"})
             self.assertEqual(row["gold_count"], "2")
             self.assertEqual(row["candidate_size"], "3")
             json.loads(row["hyperparameters"])
@@ -288,8 +288,8 @@ experiments:
                 fieldnames = reader.fieldnames
                 rows = list(reader)
 
-        self.assertEqual(len(results), 2)
-        self.assertEqual([row["model"] for row in results], ["tfidf", "bm25"])
+        self.assertEqual(len(results), 3)
+        self.assertEqual([row["model"] for row in results], ["tfidf", "bm25", "exact_match"])
         for row in results:
             self.assertEqual(list(row["recalls"].keys()), [2, 4])
 
@@ -310,7 +310,7 @@ experiments:
                 "runtime_seconds",
             ],
         )
-        self.assertEqual(len(rows), 2)
+        self.assertEqual(len(rows), 3)
         self.assertTrue(all(row["gold_count"] == "2" for row in rows))
         self.assertTrue(all(row["candidate_size"] == "3" for row in rows))
 
@@ -384,7 +384,7 @@ heldout:
 
         self.assertEqual(
             [row["dataset_name"] for row in results],
-            ["z_dataset", "z_dataset", "a_dataset", "a_dataset"],
+            ["z_dataset", "z_dataset", "z_dataset", "a_dataset", "a_dataset", "a_dataset"],
         )
 
     def test_shared_preprocessing_runs_once_per_dataset(self) -> None:
@@ -412,7 +412,7 @@ heldout:
                     config_path=config_path, output_csv_path=output_csv_path
                 )
 
-        self.assertEqual(len(results), 4)
+        self.assertEqual(len(results), 5)
         download_mock.assert_not_called()
 
     def test_best_effort_writes_successful_rows_only(self) -> None:
@@ -431,9 +431,9 @@ heldout:
             with output_csv_path.open("r", encoding="utf-8", newline="") as csv_file:
                 rows = list(csv.DictReader(csv_file))
 
-        self.assertEqual(len(results), 2)
-        self.assertEqual(len(rows), 2)
-        self.assertTrue(all(row["method"] == "bm25" for row in rows))
+        self.assertEqual(len(results), 3)
+        self.assertEqual(len(rows), 3)
+        self.assertEqual({row["method"] for row in rows}, {"bm25", "exact_match"})
 
     def test_csv_persistence_failure_does_not_abort_results(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -445,7 +445,7 @@ heldout:
             ):
                 results = run_experiments(config_path=config_path)
 
-        self.assertEqual(len(results), 4)
+        self.assertEqual(len(results), 5)
 
     def test_runner_is_deterministic(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -483,7 +483,7 @@ heldout:
         self.assertIn("Processing dataset 'fixture_dataset'", combined)
         self.assertIn("Finished dataset 'fixture_dataset' model runs", combined)
         self.assertIn("Run summary:", combined)
-        self.assertIn("successful_model_runs=4", combined)
+        self.assertIn("successful_model_runs=5", combined)
         self.assertIn("failed_model_runs=0", combined)
 
     def test_runner_failure_logs_include_summary(self) -> None:
@@ -513,7 +513,7 @@ heldout:
                 show_progress=False,
             )
 
-        self.assertEqual(len(results), 4)
+        self.assertEqual(len(results), 5)
 
     def test_runner_with_show_progress_true_uses_tqdm(self) -> None:
         call_count = 0
@@ -533,8 +533,18 @@ heldout:
                     show_progress=True,
                 )
 
-        self.assertEqual(len(results), 4)
+        self.assertEqual(len(results), 5)
         self.assertGreater(call_count, 0)
+
+    def test_exact_match_rows_use_fixed_payload_and_match_labels(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = self._write_fixture_dataset(Path(tmpdir))
+            results = run_experiments(config_path=config_path, show_progress=False)
+
+        exact_row = next(row for row in results if row["model"] == "exact_match")
+        self.assertEqual(exact_row["hyperparameters"], {"normalization": "light_v1"})
+        self.assertEqual(exact_row["mrr"], 1.0)
+        self.assertEqual(exact_row["recalls"][1], 1.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_heldout_kg_runner.py
+++ b/tests/test_heldout_kg_runner.py
@@ -238,7 +238,7 @@ class HeldoutKgRunnerTests(unittest.TestCase):
                 show_progress=False,
             )
 
-            self.assertEqual(len(results), 6)
+            self.assertEqual(len(results), 9)
             self.assertTrue(output_csv.exists())
             with output_csv.open("r", encoding="utf-8", newline="") as csv_file:
                 reader = csv.DictReader(csv_file)
@@ -263,11 +263,11 @@ class HeldoutKgRunnerTests(unittest.TestCase):
                 )
                 rows = list(reader)
 
-        self.assertEqual(len(rows), 6)
+        self.assertEqual(len(rows), 9)
         entity_types = {row["entity_type"] for row in rows}
         methods = {row["method"] for row in rows}
         self.assertEqual(entity_types, {"class", "predicate", "instance"})
-        self.assertEqual(methods, {"tfidf", "bm25"})
+        self.assertEqual(methods, {"tfidf", "bm25", "exact_match"})
 
     def test_runner_uses_frozen_settings_not_grid_search(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -282,7 +282,7 @@ class HeldoutKgRunnerTests(unittest.TestCase):
                 show_progress=False,
             )
 
-        self.assertEqual(len(results), 6)
+        self.assertEqual(len(results), 9)
         for row in results:
             if row["model"] == "tfidf":
                 self.assertEqual(
@@ -294,8 +294,10 @@ class HeldoutKgRunnerTests(unittest.TestCase):
                         "sublinear_tf": False,
                     },
                 )
-            else:
+            elif row["model"] == "bm25":
                 self.assertEqual(row["hyperparameters"], {"k1": 1.8, "b": 0.75})
+            else:
+                self.assertEqual(row["hyperparameters"], {"normalization": "light_v1"})
 
     def test_candidate_reduction_ratio_handles_target_pool_smaller_than_kmax(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -326,6 +328,25 @@ class HeldoutKgRunnerTests(unittest.TestCase):
         self.assertEqual(class_row["target_pool_size"], 3)
         self.assertEqual(class_row["retained_candidate_size"], 2)
         self.assertAlmostEqual(class_row["candidate_reduction_ratio"], 1.0 - (2.0 / 3.0))
+
+    def test_exact_match_heldout_rows_use_fixed_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config = self._write_config(tmp)
+            selected = tmp / "heldout_selected_settings.json"
+            self._write_selected_settings(selected)
+
+            results = run_heldout_kg_experiments(
+                config_path=config,
+                selected_settings_path=selected,
+                show_progress=False,
+            )
+
+        exact_rows = [row for row in results if row["model"] == "exact_match"]
+        self.assertEqual(len(exact_rows), 3)
+        for row in exact_rows:
+            self.assertEqual(row["hyperparameters"], {"normalization": "light_v1"})
+            self.assertEqual(row["mrr"], 1.0)
 
     def test_missing_selected_method_raises(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -436,4 +457,4 @@ class HeldoutKgRunnerTests(unittest.TestCase):
             finally:
                 os.chdir(old_cwd)
 
-        self.assertEqual(len(results), 6)
+        self.assertEqual(len(results), 9)


### PR DESCRIPTION
## Summary
- add a fixed `exact_match` baseline with conservative normalized exact string matching over extracted labels
- run the baseline in both development experiments and held-out KG evaluation without involving it in frozen hyperparameter selection
- document the normalization policy and add regression coverage for baseline retrieval, development execution, and held-out execution

## Testing
- ./venv/bin/python3.12 -m py_compile src/preprocessing/exact_match_normalizer.py src/retrieval/exact_match_retriever.py src/method_registry.py src/experiments/experiment_runner.py src/experiments/heldout_kg_runner.py
- ./venv/bin/python3.12 -m unittest tests.test_exact_match_retriever tests.test_experiment_runner tests.test_heldout_kg_runner tests.test_kg_heldout_reporting tests.test_model_comparison tests.test_main_cli -v

Closes #44
