### PR TITLE
feat: add char n-gram lexical baseline (#45)

### DIFF
--- a/src/experiments/experiment_runner.py
+++ b/src/experiments/experiment_runner.py
@@ -23,6 +23,7 @@ from src.preprocessing.text_preprocessor import preprocess_text, validate_nltk_a
 from src.rdf_utils.alignment_parser import load_alignment_mappings
 from src.rdf_utils.label_extractor import extract_entity_label
 from src.retrieval.bm25_retriever import Bm25Retriever
+from src.retrieval.char_ngram_retriever import CharNgramRetriever
 from src.retrieval.exact_match_retriever import ExactMatchRetriever
 from src.retrieval.tfidf_retriever import TfidfRetriever
 
@@ -205,6 +206,14 @@ def _build_exact_match_model_run() -> ModelRunSpec:
     )
 
 
+def _build_char_ngram_model_run() -> ModelRunSpec:
+    return ModelRunSpec(
+        model_name="char_ngram",
+        hyperparameters=fixed_method_hyperparameters("char_ngram"),
+        retriever=CharNgramRetriever(),
+    )
+
+
 def _build_model_runs(
     tfidf_grid: list[TfidfGridEntry], bm25_grid: list[Bm25GridEntry]
 ) -> list[ModelRunSpec]:
@@ -220,6 +229,9 @@ def _build_model_runs(
             continue
         if method_name == "exact_match":
             model_runs.append(_build_exact_match_model_run())
+            continue
+        if method_name == "char_ngram":
+            model_runs.append(_build_char_ngram_model_run())
             continue
         raise ValueError(f"Unsupported registered development method: {method_name}")
     return model_runs
@@ -385,6 +397,9 @@ def run_experiments(
                     elif run.model_name == "exact_match":
                         exact_match_retriever = cast(ExactMatchRetriever, run.retriever)
                         exact_match_retriever.fit(target_entities, target_labels)
+                    elif run.model_name == "char_ngram":
+                        char_ngram_retriever = cast(CharNgramRetriever, run.retriever)
+                        char_ngram_retriever.fit(target_entities, target_labels)
                     else:
                         raise ValueError(f"Unsupported model type: {run.model_name}")
 
@@ -406,9 +421,14 @@ def run_experiments(
                             predictions[source_id] = bm25_retriever.retrieve_tokenized(
                                 source_token_map[source_id], k=k_max
                             )
-                        else:
+                        elif run.model_name == "exact_match":
                             exact_match_retriever = cast(ExactMatchRetriever, run.retriever)
                             predictions[source_id] = exact_match_retriever.retrieve(
+                                source_label_map[source_id], k=k_max
+                            )
+                        else:
+                            char_ngram_retriever = cast(CharNgramRetriever, run.retriever)
+                            predictions[source_id] = char_ngram_retriever.retrieve(
                                 source_label_map[source_id], k=k_max
                             )
 

--- a/src/experiments/heldout_kg_runner.py
+++ b/src/experiments/heldout_kg_runner.py
@@ -35,6 +35,7 @@ from src.rdf_utils.entity_partitioning import (
 )
 from src.rdf_utils.label_extractor import extract_entity_label
 from src.retrieval.bm25_retriever import Bm25Retriever
+from src.retrieval.char_ngram_retriever import CharNgramRetriever
 from src.retrieval.exact_match_retriever import ExactMatchRetriever
 from src.retrieval.tfidf_retriever import TfidfRetriever
 
@@ -259,6 +260,17 @@ def _predict_for_method(
 
     if method_name == "exact_match":
         retriever = ExactMatchRetriever()
+        retriever.fit(target_entities, target_labels)
+        return {
+            source_id: retriever.retrieve(
+                source_label_map[source_id],
+                k=k_max,
+            )
+            for source_id in eval_sources
+        }
+
+    if method_name == "char_ngram":
+        retriever = CharNgramRetriever()
         retriever.fit(target_entities, target_labels)
         return {
             source_id: retriever.retrieve(

--- a/src/method_registry.py
+++ b/src/method_registry.py
@@ -45,6 +45,17 @@ REGISTERED_METHODS: tuple[MethodDescriptor, ...] = (
         selected_settings_required=False,
         fixed_hyperparameters={"normalization": EXACT_MATCH_NORMALIZATION_VERSION},
     ),
+    MethodDescriptor(
+        name="char_ngram",
+        tunable=False,
+        fixed=True,
+        selected_settings_required=False,
+        fixed_hyperparameters={
+            "normalization": EXACT_MATCH_NORMALIZATION_VERSION,
+            "analyzer": "char_wb",
+            "ngram_range": [3, 5],
+        },
+    ),
 )
 
 REGISTERED_METHODS_BY_NAME = {descriptor.name: descriptor for descriptor in REGISTERED_METHODS}

--- a/src/retrieval/char_ngram_retriever.py
+++ b/src/retrieval/char_ngram_retriever.py
@@ -1,0 +1,59 @@
+"""Character n-gram TF-IDF retrieval baseline."""
+
+from __future__ import annotations
+
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import linear_kernel
+from typing import Literal
+
+from src.preprocessing.exact_match_normalizer import normalize_exact_match_text
+
+CharAnalyzer = Literal["word", "char", "char_wb"]
+
+
+class CharNgramRetriever:
+    """Retrieve candidates using TF-IDF over normalized character n-grams."""
+
+    def __init__(
+        self,
+        *,
+        analyzer: CharAnalyzer = "char_wb",
+        ngram_range: tuple[int, int] = (3, 5),
+    ) -> None:
+        self._vectorizer = TfidfVectorizer(
+            analyzer=analyzer,
+            ngram_range=ngram_range,
+        )
+        self._entity_ids: list[str] = []
+        self._matrix = None
+
+    def fit(self, entity_ids: list[str], labels: list[str]) -> None:
+        """Fit the retriever over normalized labels."""
+        if len(entity_ids) != len(labels):
+            raise ValueError("entity_ids and labels must have the same length.")
+        if not entity_ids:
+            raise ValueError("entity_ids and labels must not be empty.")
+
+        sorted_pairs = sorted(zip(entity_ids, labels, strict=True), key=lambda pair: pair[0])
+        sorted_entity_ids = [entity_id for entity_id, _label in sorted_pairs]
+        normalized_labels = [
+            normalize_exact_match_text(label) for _entity_id, label in sorted_pairs
+        ]
+        self._matrix = self._vectorizer.fit_transform(normalized_labels)
+        self._entity_ids = sorted_entity_ids
+
+    def retrieve(self, query_text: str, k: int) -> list[tuple[str, float]]:
+        """Retrieve top-k candidates as (entity_id, similarity_score)."""
+        if self._matrix is None or not self._entity_ids:
+            raise ValueError("Retriever is not fitted. Call fit(...) before retrieve(...).")
+        if k <= 0:
+            raise ValueError("k must be a positive integer.")
+
+        normalized_query = normalize_exact_match_text(query_text)
+        query_vector = self._vectorizer.transform([normalized_query])
+        scores = linear_kernel(query_vector, self._matrix).ravel()
+
+        candidate_count = min(k, len(self._entity_ids))
+        order = np.lexsort((np.arange(len(scores)), -scores))[:candidate_count]
+        return [(self._entity_ids[idx], float(scores[idx])) for idx in order]

--- a/tests/test_char_ngram_retriever.py
+++ b/tests/test_char_ngram_retriever.py
@@ -1,0 +1,57 @@
+import unittest
+
+from src.retrieval.char_ngram_retriever import CharNgramRetriever
+
+
+class CharNgramRetrieverTests(unittest.TestCase):
+    def test_retrieves_similar_labels_after_light_normalization(self) -> None:
+        retriever = CharNgramRetriever()
+        retriever.fit(
+            ["urn:target:1", "urn:target:2"],
+            ["plant height", "leaf color"],
+        )
+
+        results = retriever.retrieve("PlantHeight", k=2)
+
+        self.assertEqual(results[0][0], "urn:target:1")
+        self.assertGreater(results[0][1], results[1][1])
+
+    def test_is_robust_to_separator_and_camel_case_variation(self) -> None:
+        retriever = CharNgramRetriever()
+        retriever.fit(
+            ["urn:target:1", "urn:target:2"],
+            ["member of", "appears in"],
+        )
+
+        results = retriever.retrieve("memberOf", k=2)
+
+        self.assertEqual(results[0][0], "urn:target:1")
+
+    def test_deterministic_tie_ordering_uses_target_uri_order(self) -> None:
+        retriever = CharNgramRetriever()
+        retriever.fit(
+            ["urn:target:b", "urn:target:a"],
+            ["hero", "hero"],
+        )
+
+        results = retriever.retrieve("hero", k=2)
+
+        self.assertEqual([entity_id for entity_id, _score in results], ["urn:target:a", "urn:target:b"])
+        self.assertAlmostEqual(results[0][1], 1.0)
+        self.assertAlmostEqual(results[1][1], 1.0)
+
+    def test_weak_overlap_still_returns_scored_candidates(self) -> None:
+        retriever = CharNgramRetriever()
+        retriever.fit(
+            ["urn:target:1", "urn:target:2"],
+            ["thor", "loki"],
+        )
+
+        results = retriever.retrieve("asgard", k=2)
+
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all(isinstance(score, float) for _, score in results))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -173,10 +173,10 @@ heldout:
             self.assertTrue(output_csv_path.exists())
 
         self.assertTrue(results)
-        self.assertEqual(len(results), 5)  # 2 TF-IDF configs + 2 BM25 configs + 1 exact match
+        self.assertEqual(len(results), 6)  # 2 TF-IDF configs + 2 BM25 configs + 2 fixed baselines
 
         models = {row["model"] for row in results}
-        self.assertEqual(models, {"tfidf", "bm25", "exact_match"})
+        self.assertEqual(models, {"tfidf", "bm25", "exact_match", "char_ngram"})
 
         for row in results:
             for key in (
@@ -251,7 +251,7 @@ heldout:
         self.assertEqual(len(rows), len(results))
         for row in rows:
             self.assertEqual(row["dataset"], "fixture_dataset")
-            self.assertIn(row["method"], {"tfidf", "bm25", "exact_match"})
+            self.assertIn(row["method"], {"tfidf", "bm25", "exact_match", "char_ngram"})
             self.assertEqual(row["gold_count"], "2")
             self.assertEqual(row["candidate_size"], "3")
             json.loads(row["hyperparameters"])
@@ -288,8 +288,8 @@ experiments:
                 fieldnames = reader.fieldnames
                 rows = list(reader)
 
-        self.assertEqual(len(results), 3)
-        self.assertEqual([row["model"] for row in results], ["tfidf", "bm25", "exact_match"])
+        self.assertEqual(len(results), 4)
+        self.assertEqual([row["model"] for row in results], ["tfidf", "bm25", "exact_match", "char_ngram"])
         for row in results:
             self.assertEqual(list(row["recalls"].keys()), [2, 4])
 
@@ -310,7 +310,7 @@ experiments:
                 "runtime_seconds",
             ],
         )
-        self.assertEqual(len(rows), 3)
+        self.assertEqual(len(rows), 4)
         self.assertTrue(all(row["gold_count"] == "2" for row in rows))
         self.assertTrue(all(row["candidate_size"] == "3" for row in rows))
 
@@ -384,7 +384,7 @@ heldout:
 
         self.assertEqual(
             [row["dataset_name"] for row in results],
-            ["z_dataset", "z_dataset", "z_dataset", "a_dataset", "a_dataset", "a_dataset"],
+            ["z_dataset", "z_dataset", "z_dataset", "z_dataset", "a_dataset", "a_dataset", "a_dataset", "a_dataset"],
         )
 
     def test_shared_preprocessing_runs_once_per_dataset(self) -> None:
@@ -412,7 +412,7 @@ heldout:
                     config_path=config_path, output_csv_path=output_csv_path
                 )
 
-        self.assertEqual(len(results), 5)
+        self.assertEqual(len(results), 6)
         download_mock.assert_not_called()
 
     def test_best_effort_writes_successful_rows_only(self) -> None:
@@ -431,9 +431,9 @@ heldout:
             with output_csv_path.open("r", encoding="utf-8", newline="") as csv_file:
                 rows = list(csv.DictReader(csv_file))
 
-        self.assertEqual(len(results), 3)
-        self.assertEqual(len(rows), 3)
-        self.assertEqual({row["method"] for row in rows}, {"bm25", "exact_match"})
+        self.assertEqual(len(results), 4)
+        self.assertEqual(len(rows), 4)
+        self.assertEqual({row["method"] for row in rows}, {"bm25", "exact_match", "char_ngram"})
 
     def test_csv_persistence_failure_does_not_abort_results(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -445,7 +445,7 @@ heldout:
             ):
                 results = run_experiments(config_path=config_path)
 
-        self.assertEqual(len(results), 5)
+        self.assertEqual(len(results), 6)
 
     def test_runner_is_deterministic(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -483,7 +483,7 @@ heldout:
         self.assertIn("Processing dataset 'fixture_dataset'", combined)
         self.assertIn("Finished dataset 'fixture_dataset' model runs", combined)
         self.assertIn("Run summary:", combined)
-        self.assertIn("successful_model_runs=5", combined)
+        self.assertIn("successful_model_runs=6", combined)
         self.assertIn("failed_model_runs=0", combined)
 
     def test_runner_failure_logs_include_summary(self) -> None:
@@ -513,7 +513,7 @@ heldout:
                 show_progress=False,
             )
 
-        self.assertEqual(len(results), 5)
+        self.assertEqual(len(results), 6)
 
     def test_runner_with_show_progress_true_uses_tqdm(self) -> None:
         call_count = 0
@@ -533,7 +533,7 @@ heldout:
                     show_progress=True,
                 )
 
-        self.assertEqual(len(results), 5)
+        self.assertEqual(len(results), 6)
         self.assertGreater(call_count, 0)
 
     def test_exact_match_rows_use_fixed_payload_and_match_labels(self) -> None:
@@ -545,6 +545,23 @@ heldout:
         self.assertEqual(exact_row["hyperparameters"], {"normalization": "light_v1"})
         self.assertEqual(exact_row["mrr"], 1.0)
         self.assertEqual(exact_row["recalls"][1], 1.0)
+
+    def test_char_ngram_rows_use_fixed_payload_and_match_labels(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = self._write_fixture_dataset(Path(tmpdir))
+            results = run_experiments(config_path=config_path, show_progress=False)
+
+        char_ngram_row = next(row for row in results if row["model"] == "char_ngram")
+        self.assertEqual(
+            char_ngram_row["hyperparameters"],
+            {
+                "normalization": "light_v1",
+                "analyzer": "char_wb",
+                "ngram_range": [3, 5],
+            },
+        )
+        self.assertEqual(char_ngram_row["mrr"], 1.0)
+        self.assertEqual(char_ngram_row["recalls"][1], 1.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_heldout_kg_runner.py
+++ b/tests/test_heldout_kg_runner.py
@@ -238,7 +238,7 @@ class HeldoutKgRunnerTests(unittest.TestCase):
                 show_progress=False,
             )
 
-            self.assertEqual(len(results), 9)
+            self.assertEqual(len(results), 12)
             self.assertTrue(output_csv.exists())
             with output_csv.open("r", encoding="utf-8", newline="") as csv_file:
                 reader = csv.DictReader(csv_file)
@@ -263,11 +263,11 @@ class HeldoutKgRunnerTests(unittest.TestCase):
                 )
                 rows = list(reader)
 
-        self.assertEqual(len(rows), 9)
+        self.assertEqual(len(rows), 12)
         entity_types = {row["entity_type"] for row in rows}
         methods = {row["method"] for row in rows}
         self.assertEqual(entity_types, {"class", "predicate", "instance"})
-        self.assertEqual(methods, {"tfidf", "bm25", "exact_match"})
+        self.assertEqual(methods, {"tfidf", "bm25", "exact_match", "char_ngram"})
 
     def test_runner_uses_frozen_settings_not_grid_search(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -282,7 +282,7 @@ class HeldoutKgRunnerTests(unittest.TestCase):
                 show_progress=False,
             )
 
-        self.assertEqual(len(results), 9)
+        self.assertEqual(len(results), 12)
         for row in results:
             if row["model"] == "tfidf":
                 self.assertEqual(
@@ -296,8 +296,17 @@ class HeldoutKgRunnerTests(unittest.TestCase):
                 )
             elif row["model"] == "bm25":
                 self.assertEqual(row["hyperparameters"], {"k1": 1.8, "b": 0.75})
-            else:
+            elif row["model"] == "exact_match":
                 self.assertEqual(row["hyperparameters"], {"normalization": "light_v1"})
+            else:
+                self.assertEqual(
+                    row["hyperparameters"],
+                    {
+                        "normalization": "light_v1",
+                        "analyzer": "char_wb",
+                        "ngram_range": [3, 5],
+                    },
+                )
 
     def test_candidate_reduction_ratio_handles_target_pool_smaller_than_kmax(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -346,6 +355,32 @@ class HeldoutKgRunnerTests(unittest.TestCase):
         self.assertEqual(len(exact_rows), 3)
         for row in exact_rows:
             self.assertEqual(row["hyperparameters"], {"normalization": "light_v1"})
+            self.assertEqual(row["mrr"], 1.0)
+
+    def test_char_ngram_heldout_rows_use_fixed_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config = self._write_config(tmp)
+            selected = tmp / "heldout_selected_settings.json"
+            self._write_selected_settings(selected)
+
+            results = run_heldout_kg_experiments(
+                config_path=config,
+                selected_settings_path=selected,
+                show_progress=False,
+            )
+
+        char_ngram_rows = [row for row in results if row["model"] == "char_ngram"]
+        self.assertEqual(len(char_ngram_rows), 3)
+        for row in char_ngram_rows:
+            self.assertEqual(
+                row["hyperparameters"],
+                {
+                    "normalization": "light_v1",
+                    "analyzer": "char_wb",
+                    "ngram_range": [3, 5],
+                },
+            )
             self.assertEqual(row["mrr"], 1.0)
 
     def test_missing_selected_method_raises(self) -> None:
@@ -457,4 +492,4 @@ class HeldoutKgRunnerTests(unittest.TestCase):
             finally:
                 os.chdir(old_cwd)
 
-        self.assertEqual(len(results), 9)
+        self.assertEqual(len(results), 12)


### PR DESCRIPTION
## Summary
- add a fixed `char_ngram` lexical baseline using TF-IDF over normalized character n-grams
- run the baseline in both development experiments and held-out KG evaluation without involving it in frozen hyperparameter selection
- add regression coverage for deterministic tie ordering, development execution, and held-out execution with the new method

## Testing
- ./venv/bin/python3.12 -m unittest tests.test_char_ngram_retriever tests.test_heldout_kg_runner tests.test_experiment_runner tests.test_kg_heldout_reporting tests.test_model_comparison tests.test_main_cli -v

Closes #45
