### PR TITLE
feat: add held-out inference intervals and significance testing (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,8 +562,27 @@ Generated files:
 - `kg_heldout_macro_summary.csv`
 - `kg_heldout_micro_summary.csv`
 - `kg_heldout_reduction_effectiveness.csv`
+- `kg_heldout_pairwise_by_type_inference.csv`
+- `kg_heldout_pairwise_overall_inference.csv`
 - `kg_heldout_interpretation_scaffold.md`
 - `kg_heldout_transfer_summary.csv` when a compatible selected-settings artifact is available
+
+Inferential testing design:
+
+- Problem: exact paired sign-flip testing scales as `2^n` in the number of non-zero
+  paired deltas, which becomes impractical as held-out comparisons grow.
+- Alternatives considered:
+  - full exact enumeration for all `n`
+  - asymptotic-only approximation
+  - randomization/permutation sampling
+- Chosen approach:
+  - hybrid exact + deterministic randomization
+  - exact paired sign-flip p-values for small `n`
+  - deterministic Monte Carlo sign-flip fallback for larger `n` (fixed seed and
+    fixed draw count)
+- Confidence intervals use deterministic paired bootstrap resampling.
+- Inferential targets include `mrr` and `recall_at_<k>` metrics.
+- `candidate_reduction_ratio` remains descriptive and is not significance-tested.
 
 ## Held-Out Full Run
 

--- a/src/analysis/heldout_inference.py
+++ b/src/analysis/heldout_inference.py
@@ -1,0 +1,118 @@
+"""Deterministic inferential helpers for held-out pairwise comparisons.
+
+Sign-flip p-value scalability note
+---------------------------------
+Problem:
+- Exact paired sign-flip testing enumerates ``2^n`` sign assignments for ``n``
+  non-zero paired deltas. This grows exponentially and can become impractical
+  for larger held-out comparisons.
+
+Alternatives considered:
+- Keep full exact enumeration always (simple but not scalable).
+- Use asymptotic approximations only (fast but less faithful for small n).
+- Use randomization/permutation sampling for large n.
+
+Chosen approach:
+- Hybrid exact + deterministic randomization:
+  - For small ``n``, use exact enumeration.
+  - Above a fixed threshold, use a deterministic Monte Carlo sign-flip
+    approximation with a fixed seed and fixed number of draws.
+"""
+
+from __future__ import annotations
+
+from itertools import product
+from typing import Iterable
+
+import numpy as np
+
+BOOTSTRAP_CONFIDENCE_LEVEL = 0.95
+BOOTSTRAP_RESAMPLES = 10_000
+BOOTSTRAP_SEED = 1729
+SIGN_FLIP_EXACT_MAX_NONZERO = 20
+SIGN_FLIP_MONTE_CARLO_DRAWS = 100_000
+
+
+def coerce_deltas(values: Iterable[float]) -> np.ndarray:
+    """Convert paired deltas to a stable float array."""
+    deltas = np.asarray(list(values), dtype=float)
+    if deltas.ndim != 1:
+        raise ValueError("Paired deltas must be a one-dimensional sequence.")
+    if deltas.size == 0:
+        raise ValueError("Paired deltas must not be empty.")
+    return deltas
+
+
+def paired_bootstrap_confidence_interval(
+    deltas: Iterable[float],
+    *,
+    confidence_level: float = BOOTSTRAP_CONFIDENCE_LEVEL,
+    resamples: int = BOOTSTRAP_RESAMPLES,
+    seed: int = BOOTSTRAP_SEED,
+) -> tuple[float, float]:
+    """Return a deterministic percentile bootstrap CI over paired mean deltas."""
+    observed = coerce_deltas(deltas)
+    if not 0.0 < confidence_level < 1.0:
+        raise ValueError("confidence_level must be between 0 and 1.")
+    if resamples <= 0:
+        raise ValueError("resamples must be a positive integer.")
+
+    rng = np.random.default_rng(seed)
+    sample_size = observed.size
+    sample_indices = rng.integers(0, sample_size, size=(resamples, sample_size))
+    resampled_means = observed[sample_indices].mean(axis=1)
+    alpha = (1.0 - confidence_level) / 2.0
+    lower = float(np.quantile(resampled_means, alpha))
+    upper = float(np.quantile(resampled_means, 1.0 - alpha))
+    return lower, upper
+
+
+def exact_paired_sign_flip_p_value(deltas: Iterable[float]) -> float:
+    """Return a two-sided paired sign-flip p-value for mean delta.
+
+    Uses exact enumeration for small sample sizes and deterministic Monte Carlo
+    randomization above ``SIGN_FLIP_EXACT_MAX_NONZERO``.
+    """
+    return paired_sign_flip_p_value(deltas)
+
+
+def paired_sign_flip_p_value(
+    deltas: Iterable[float],
+    *,
+    exact_max_nonzero: int = SIGN_FLIP_EXACT_MAX_NONZERO,
+    monte_carlo_draws: int = SIGN_FLIP_MONTE_CARLO_DRAWS,
+    seed: int = BOOTSTRAP_SEED,
+) -> float:
+    """Return a two-sided paired sign-flip p-value for mean delta.
+
+    - Exact enumeration when non-zero paired deltas <= ``exact_max_nonzero``.
+    - Deterministic Monte Carlo approximation otherwise.
+    """
+    observed = coerce_deltas(deltas)
+    nonzero = observed[observed != 0.0]
+    if nonzero.size == 0:
+        return 1.0
+    if exact_max_nonzero < 0:
+        raise ValueError("exact_max_nonzero must be non-negative.")
+    if monte_carlo_draws <= 0:
+        raise ValueError("monte_carlo_draws must be positive.")
+
+    absolute = np.abs(nonzero)
+    observed_statistic = float(abs(nonzero.sum()))
+    tolerance = 1e-12
+
+    if absolute.size <= exact_max_nonzero:
+        extreme_assignments = 0
+        total_assignments = 2 ** absolute.size
+        for sign_pattern in product((-1.0, 1.0), repeat=absolute.size):
+            signed_sum = float(np.dot(np.asarray(sign_pattern, dtype=float), absolute))
+            if abs(signed_sum) + tolerance >= observed_statistic:
+                extreme_assignments += 1
+        return float(extreme_assignments / total_assignments)
+
+    rng = np.random.default_rng(seed)
+    signs = rng.choice((-1.0, 1.0), size=(monte_carlo_draws, absolute.size))
+    sampled_sums = signs @ absolute
+    extreme = np.abs(sampled_sums) + tolerance >= observed_statistic
+    # Plus-one correction avoids pathological zero p-values under sampling.
+    return float((extreme.sum() + 1) / (monte_carlo_draws + 1))

--- a/src/analysis/kg_heldout_reporting.py
+++ b/src/analysis/kg_heldout_reporting.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import csv
-from datetime import datetime
+from itertools import combinations
 import json
 import logging
 from pathlib import Path
-from typing import Any
 
 import pandas as pd
 
+from src.analysis.heldout_inference import (
+    paired_sign_flip_p_value,
+    paired_bootstrap_confidence_interval,
+)
 from src.method_registry import PRIMARY_COMPARISON_METHODS, ordered_method_names, supports_primary_comparison
 
 logger = logging.getLogger(__name__)
@@ -37,12 +40,18 @@ class KgHeldoutReportingValidationError(ValueError):
 
 
 def _coerce_float(value: object) -> float:
-    if isinstance(value, bool):
+    if isinstance(value, str):
         return float(value)
     if isinstance(value, (int, float)):
         return float(value)
-    if isinstance(value, str):
-        return float(value)
+    # Handle numpy-style scalar objects (for example np.int64 / np.float64).
+    if hasattr(value, "item"):
+        try:
+            scalar_value = value.item()  # type: ignore[call-arg]
+        except (TypeError, ValueError, AttributeError):
+            scalar_value = None
+        if isinstance(scalar_value, (int, float, str)):
+            return float(scalar_value)
     raise TypeError(f"Unsupported float value: {value!r}")
 
 
@@ -248,9 +257,10 @@ def _delta_row(
 
     row: dict[str, object] = {method_column: "delta_tfidf_minus_bm25"}
     for column in value_columns:
+        left_value = _coerce_float(indexed.loc[PRIMARY_COMPARISON_METHODS[0], column])
+        right_value = _coerce_float(indexed.loc[PRIMARY_COMPARISON_METHODS[1], column])
         row[column] = float(
-            indexed.loc[PRIMARY_COMPARISON_METHODS[0], column]
-            - indexed.loc[PRIMARY_COMPARISON_METHODS[1], column]
+            left_value - right_value
         )
     return row
 
@@ -382,10 +392,18 @@ def _build_reduction_effectiveness(
         .sort_index()
     )
 
-    def paired_value(row: pd.Series, metric: str, method: str) -> float:
+    def paired_value(
+        *,
+        track: str,
+        version: str,
+        dataset: str,
+        entity_type: str,
+        metric: str,
+        method: str,
+    ) -> float:
         return _coerce_float(
             paired.loc[
-                (row["track"], row["version"], row["dataset"], row["entity_type"]),
+                (track, version, dataset, entity_type),
                 (metric, method),
             ]
         )
@@ -403,11 +421,21 @@ def _build_reduction_effectiveness(
             if current_method not in other_method_map:
                 deltas.append(None)
                 continue
-            current_value = paired_value(pd.Series(row._asdict()), metric, current_method)
+            current_value = paired_value(
+                track=str(row.track),
+                version=str(row.version),
+                dataset=str(row.dataset),
+                entity_type=str(row.entity_type),
+                metric=metric,
+                method=current_method,
+            )
             other_value = paired_value(
-                pd.Series(row._asdict()),
-                metric,
-                other_method_map[current_method],
+                track=str(row.track),
+                version=str(row.version),
+                dataset=str(row.dataset),
+                entity_type=str(row.entity_type),
+                metric=metric,
+                method=other_method_map[current_method],
             )
             deltas.append(float(current_value - other_value))
         enriched[delta_column] = deltas
@@ -415,6 +443,175 @@ def _build_reduction_effectiveness(
     return enriched.sort_values(
         ["track", "dataset", "entity_type", "method"], kind="mergesort"
     ).reset_index(drop=True)
+
+
+def _pairwise_method_pairs(methods: list[str]) -> list[tuple[str, str]]:
+    """Return canonical unordered method pairs following registry order."""
+    return list(combinations(ordered_method_names(methods), 2))
+
+
+PAIRWISE_INFERENCE_COLUMNS = [
+    "metric",
+    "method_a",
+    "method_b",
+    "paired_unit_count",
+    "nonzero_delta_count",
+    "method_a_mean",
+    "method_b_mean",
+    "paired_delta",
+    "ci_lower",
+    "ci_upper",
+    "p_value",
+]
+
+
+def _empty_pairwise_inference_frame(*, scope_column: str) -> pd.DataFrame:
+    return pd.DataFrame(columns=[scope_column, *PAIRWISE_INFERENCE_COLUMNS])
+
+
+def _build_pairwise_inference_row(
+    paired_frame: pd.DataFrame,
+    *,
+    metric: str,
+    method_a: str,
+    method_b: str,
+    extra_fields: dict[str, object],
+) -> dict[str, object]:
+    method_a_values = paired_frame[method_a].astype(float)
+    method_b_values = paired_frame[method_b].astype(float)
+    deltas = method_a_values - method_b_values
+    ci_lower, ci_upper = paired_bootstrap_confidence_interval(deltas.tolist())
+    return {
+        **extra_fields,
+        "metric": metric,
+        "method_a": method_a,
+        "method_b": method_b,
+        "paired_unit_count": int(len(paired_frame)),
+        "nonzero_delta_count": int((deltas != 0.0).sum()),
+        "method_a_mean": float(method_a_values.mean()),
+        "method_b_mean": float(method_b_values.mean()),
+        "paired_delta": float(deltas.mean()),
+        "ci_lower": ci_lower,
+        "ci_upper": ci_upper,
+        "p_value": paired_sign_flip_p_value(deltas.tolist()),
+    }
+
+
+def _build_pairwise_by_type_inference(
+    frame: pd.DataFrame,
+    recall_columns: list[str],
+    methods: list[str],
+) -> pd.DataFrame:
+    method_pairs = _pairwise_method_pairs(methods)
+    if not method_pairs:
+        return _empty_pairwise_inference_frame(scope_column="entity_type")
+
+    metrics = ["mrr", *recall_columns]
+    rows: list[dict[str, object]] = []
+
+    for entity_type in sorted(REQUIRED_ENTITY_TYPES):
+        subset = frame[frame["entity_type"] == entity_type].copy()
+        for metric in metrics:
+            paired_metric = (
+                subset.pivot(
+                    index=["track", "version", "dataset"],
+                    columns="method",
+                    values=metric,
+                )
+                .sort_index()
+            )
+            for method_a, method_b in method_pairs:
+                rows.append(
+                    _build_pairwise_inference_row(
+                        paired_metric[[method_a, method_b]],
+                        metric=metric,
+                        method_a=method_a,
+                        method_b=method_b,
+                        extra_fields={"entity_type": entity_type},
+                    )
+                )
+
+    result = pd.DataFrame(rows)
+    method_order = {method: index for index, method in enumerate(ordered_method_names(methods))}
+    result["_method_a_order"] = result["method_a"].map(
+        lambda value: method_order.get(str(value), len(method_order))
+    )
+    result["_method_b_order"] = result["method_b"].map(
+        lambda value: method_order.get(str(value), len(method_order))
+    )
+    return result.sort_values(
+        ["entity_type", "metric", "_method_a_order", "_method_b_order", "method_a", "method_b"],
+        kind="mergesort",
+    ).drop(columns=["_method_a_order", "_method_b_order"]).reset_index(drop=True)
+
+
+def _build_pairwise_overall_inference(
+    frame: pd.DataFrame,
+    recall_columns: list[str],
+    methods: list[str],
+) -> pd.DataFrame:
+    method_pairs = _pairwise_method_pairs(methods)
+    if not method_pairs:
+        return _empty_pairwise_inference_frame(scope_column="aggregation_scope")
+
+    metrics = ["mrr", *recall_columns]
+    rows: list[dict[str, object]] = []
+
+    overall_pivot_by_metric: dict[str, pd.DataFrame] = {}
+    for metric in metrics:
+        overall_pivot_by_metric[metric] = (
+            frame.pivot(
+                index=["track", "version", "dataset", "entity_type"],
+                columns="method",
+                values=metric,
+            )
+            .sort_index()
+        )
+
+    type_means = (
+        frame.groupby(["entity_type", "method"], as_index=False)[metrics]
+        .mean(numeric_only=True)
+        .sort_values(["entity_type", "method"], kind="mergesort")
+    )
+    macro_pivot_by_metric: dict[str, pd.DataFrame] = {}
+    for metric in metrics:
+        macro_pivot_by_metric[metric] = (
+            type_means.pivot(index="entity_type", columns="method", values=metric).sort_index()
+        )
+
+    for metric in metrics:
+        for method_a, method_b in method_pairs:
+            rows.append(
+                _build_pairwise_inference_row(
+                    overall_pivot_by_metric[metric][[method_a, method_b]],
+                    metric=metric,
+                    method_a=method_a,
+                    method_b=method_b,
+                    extra_fields={"aggregation_scope": "overall_dataset_type_rows"},
+                )
+            )
+            rows.append(
+                _build_pairwise_inference_row(
+                    macro_pivot_by_metric[metric][[method_a, method_b]],
+                    metric=metric,
+                    method_a=method_a,
+                    method_b=method_b,
+                    extra_fields={"aggregation_scope": "macro_entity_type_means"},
+                )
+            )
+
+    result = pd.DataFrame(rows)
+    method_order = {method: index for index, method in enumerate(ordered_method_names(methods))}
+    result["_method_a_order"] = result["method_a"].map(
+        lambda value: method_order.get(str(value), len(method_order))
+    )
+    result["_method_b_order"] = result["method_b"].map(
+        lambda value: method_order.get(str(value), len(method_order))
+    )
+    return result.sort_values(
+        ["aggregation_scope", "metric", "_method_a_order", "_method_b_order", "method_a", "method_b"],
+        kind="mergesort",
+    ).drop(columns=["_method_a_order", "_method_b_order"]).reset_index(drop=True)
 
 
 def _load_selected_settings_payload(
@@ -515,6 +712,8 @@ def _write_interpretation_scaffold(
     macro_summary: pd.DataFrame,
     micro_summary: pd.DataFrame,
     reduction_effectiveness: pd.DataFrame,
+    pairwise_by_type_inference: pd.DataFrame,
+    pairwise_overall_inference: pd.DataFrame,
     primary_recall_column: str,
     transfer_summary: pd.DataFrame | None,
     transfer_note: str | None,
@@ -552,6 +751,48 @@ def _write_interpretation_scaffold(
     reduction_snapshot = reduction_snapshot.sort_values(
         ["entity_type", "method"], kind="mergesort"
     ).groupby(["entity_type", "method"], as_index=False).mean(numeric_only=True)
+
+    mrr_pairwise_by_type = pairwise_by_type_inference[
+        pairwise_by_type_inference["metric"] == "mrr"
+    ].copy()
+    strongest_pairwise: list[str] = []
+    for entity_type in sorted(REQUIRED_ENTITY_TYPES):
+        group = mrr_pairwise_by_type[mrr_pairwise_by_type["entity_type"] == entity_type].copy()
+        if group.empty:
+            continue
+        ranked = group.assign(abs_delta=group["paired_delta"].abs()).sort_values(
+            ["abs_delta", "method_a", "method_b"],
+            ascending=[False, True, True],
+            kind="mergesort",
+        )
+        best = ranked.iloc[0]
+        strongest_pairwise.append(
+            f"- `{entity_type}`: `{best['method_a']}` vs `{best['method_b']}` "
+            f"delta `{best['paired_delta']:.6f}`, CI [`{best['ci_lower']:.6f}`, `{best['ci_upper']:.6f}`], "
+            f"p-value `{best['p_value']:.6f}`"
+        )
+
+    directional_consistency: list[str] = []
+    for method_a, method_b in _pairwise_method_pairs(methods):
+        pair_rows = mrr_pairwise_by_type[
+            (mrr_pairwise_by_type["method_a"] == method_a)
+            & (mrr_pairwise_by_type["method_b"] == method_b)
+        ].copy()
+        if pair_rows.empty:
+            continue
+        signs = {float(value) > 0.0 for value in pair_rows["paired_delta"] if float(value) != 0.0}
+        status = "directionally consistent" if len(signs) <= 1 else "mixed direction"
+        directional_consistency.append(f"- `{method_a}` vs `{method_b}`: {status}")
+
+    overall_mrr = pairwise_overall_inference[
+        pairwise_overall_inference["metric"] == "mrr"
+    ].copy().sort_values(
+        ["aggregation_scope", "method_a", "method_b"], kind="mergesort"
+    )
+    ci_overlap_zero = mrr_pairwise_by_type[
+        (mrr_pairwise_by_type["ci_lower"] <= 0.0)
+        & (mrr_pairwise_by_type["ci_upper"] >= 0.0)
+    ].copy().sort_values(["entity_type", "method_a", "method_b"], kind="mergesort")
 
     lines = [
         "# KG Held-Out Interpretation Scaffold",
@@ -591,13 +832,42 @@ def _write_interpretation_scaffold(
 
     lines.extend(
         [
-        "## Reduction vs Effectiveness Prompts",
-        "",
-        f"- Review `{primary_recall_column}` alongside `candidate_reduction_ratio` for each entity type.",
-        "- Check whether the higher-reduction method also preserves MRR consistency across entity types.",
-        "",
+            "## Reduction vs Effectiveness Prompts",
+            "",
+            f"- Review `{primary_recall_column}` alongside `candidate_reduction_ratio` for each entity type.",
+            "- Check whether the higher-reduction method also preserves MRR consistency across entity types.",
+            "- Candidate Reduction Ratio is descriptive only and is not included in significance testing.",
+            "",
+            "## Pairwise Inference Snapshot",
+            "",
+            "### Strongest Per-Type MRR Comparisons",
+            "",
+            *strongest_pairwise,
+            "",
+            "### Directional Consistency Across Entity Types",
+            "",
+            *directional_consistency,
+            "",
+            "### Overall MRR Inference",
+            "",
         ]
     )
+    for row in overall_mrr.itertuples(index=False):
+        lines.append(
+            f"- `{row.aggregation_scope}` / `{row.method_a}` vs `{row.method_b}`: "
+            f"delta `{row.paired_delta:.6f}`, CI [`{row.ci_lower:.6f}`, `{row.ci_upper:.6f}`], "
+            f"p-value `{row.p_value:.6f}`"
+        )
+    lines.extend(["", "### MRR Comparisons With CI Overlap At Zero", ""])
+    if ci_overlap_zero.empty:
+        lines.append("- None.")
+    else:
+        for row in ci_overlap_zero.itertuples(index=False):
+            lines.append(
+                f"- `{row.entity_type}` / `{row.method_a}` vs `{row.method_b}` "
+                f"CI [`{row.ci_lower:.6f}`, `{row.ci_upper:.6f}`], p-value `{row.p_value:.6f}`"
+            )
+    lines.append("")
 
     if transfer_summary is not None:
         lines.extend(
@@ -652,6 +922,12 @@ def generate_kg_heldout_reporting(
     macro_summary = _build_macro_summary(by_type_summary, recall_columns, methods)
     micro_summary = _build_micro_summary(validated, recall_columns, methods)
     reduction_effectiveness = _build_reduction_effectiveness(validated, recall_columns, methods)
+    pairwise_by_type_inference = _build_pairwise_by_type_inference(
+        validated, recall_columns, methods
+    )
+    pairwise_overall_inference = _build_pairwise_overall_inference(
+        validated, recall_columns, methods
+    )
 
     selected_settings_json, selected_settings_explicit = _resolve_selected_settings_json(
         selected_settings_path,
@@ -676,6 +952,8 @@ def generate_kg_heldout_reporting(
     macro_path = output_root / "kg_heldout_macro_summary.csv"
     micro_path = output_root / "kg_heldout_micro_summary.csv"
     reduction_path = output_root / "kg_heldout_reduction_effectiveness.csv"
+    pairwise_by_type_path = output_root / "kg_heldout_pairwise_by_type_inference.csv"
+    pairwise_overall_path = output_root / "kg_heldout_pairwise_overall_inference.csv"
     interpretation_path = output_root / "kg_heldout_interpretation_scaffold.md"
     transfer_path = output_root / "kg_heldout_transfer_summary.csv"
     manifest_path = output_root / "manifest.txt"
@@ -684,6 +962,8 @@ def generate_kg_heldout_reporting(
     macro_summary.to_csv(macro_path, index=False)
     micro_summary.to_csv(micro_path, index=False)
     reduction_effectiveness.to_csv(reduction_path, index=False, quoting=csv.QUOTE_MINIMAL)
+    pairwise_by_type_inference.to_csv(pairwise_by_type_path, index=False)
+    pairwise_overall_inference.to_csv(pairwise_overall_path, index=False)
     if transfer_summary is not None:
         transfer_summary.to_csv(transfer_path, index=False)
 
@@ -695,6 +975,8 @@ def generate_kg_heldout_reporting(
         macro_summary=macro_summary,
         micro_summary=micro_summary,
         reduction_effectiveness=reduction_effectiveness,
+        pairwise_by_type_inference=pairwise_by_type_inference,
+        pairwise_overall_inference=pairwise_overall_inference,
         primary_recall_column=primary_recall_column,
         transfer_summary=transfer_summary,
         transfer_note=transfer_note,
@@ -702,7 +984,6 @@ def generate_kg_heldout_reporting(
     )
 
     manifest_lines = [
-        f"generated_at={datetime.now().isoformat(timespec='seconds')}",
         f"source_csv={source_csv}",
         f"output_dir={output_root}",
         f"selected_settings_json={selected_settings_json}" if selected_settings_json is not None else "selected_settings_json=",
@@ -716,6 +997,8 @@ def generate_kg_heldout_reporting(
         "kg_heldout_macro_summary": macro_path,
         "kg_heldout_micro_summary": micro_path,
         "kg_heldout_reduction_effectiveness": reduction_path,
+        "kg_heldout_pairwise_by_type_inference": pairwise_by_type_path,
+        "kg_heldout_pairwise_overall_inference": pairwise_overall_path,
         "kg_heldout_interpretation_scaffold": interpretation_path,
         "manifest": manifest_path,
     }

--- a/tests/test_kg_heldout_reporting.py
+++ b/tests/test_kg_heldout_reporting.py
@@ -5,6 +5,11 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from src.analysis.heldout_inference import (
+    exact_paired_sign_flip_p_value,
+    paired_sign_flip_p_value,
+    paired_bootstrap_confidence_interval,
+)
 from src.analysis.kg_heldout_reporting import (
     KgHeldoutReportingValidationError,
     generate_kg_heldout_reporting,
@@ -209,106 +214,38 @@ class KgHeldoutReportingTests(unittest.TestCase):
         ]
 
         if include_extra_method:
-            rows.extend(
-                [
+            extra_rows: list[dict[str, object]] = []
+            for row in rows:
+                if row["method"] != "tfidf":
+                    continue
+
+                exact_row = dict(row)
+                exact_row.update(
                     {
-                        "track": "kg",
-                        "version": "heldout-v1",
-                        "dataset": "d1",
-                        "entity_type": "class",
-                        "method": "chargram",
-                        "hyperparameters": '{"cfg":"chargram"}',
-                        "gold_count": 10,
-                        "target_pool_size": 100,
-                        "retained_candidate_size": 50,
-                        "candidate_reduction_ratio": 0.50,
-                        "recall_at_1": 0.65,
-                        "recall_at_50": 0.91,
-                        "mrr": 0.82,
+                        "method": "exact_match",
+                        "hyperparameters": '{"normalization":"light_v1"}',
+                        "recall_at_1": max(0.0, float(row["recall_at_1"]) - 0.05),
+                        "recall_at_50": max(0.0, float(row["recall_at_50"]) - 0.03),
+                        "mrr": max(0.0, float(row["mrr"]) - 0.06),
                         "runtime_seconds": 0.08,
-                    },
+                    }
+                )
+                extra_rows.append(exact_row)
+
+                char_ngram_row = dict(row)
+                char_ngram_row.update(
                     {
-                        "track": "kg",
-                        "version": "heldout-v1",
-                        "dataset": "d2",
-                        "entity_type": "class",
-                        "method": "chargram",
-                        "hyperparameters": '{"cfg":"chargram"}',
-                        "gold_count": 1,
-                        "target_pool_size": 80,
-                        "retained_candidate_size": 40,
-                        "candidate_reduction_ratio": 0.50,
-                        "recall_at_1": 0.45,
-                        "recall_at_50": 0.75,
-                        "mrr": 0.62,
+                        "method": "char_ngram",
+                        "hyperparameters": '{"normalization":"light_v1","analyzer":"char_wb","ngram_range":[3,5]}',
+                        "recall_at_1": max(0.0, float(row["recall_at_1"]) - 0.02),
+                        "recall_at_50": max(0.0, float(row["recall_at_50"]) - 0.01),
+                        "mrr": max(0.0, float(row["mrr"]) - 0.03),
                         "runtime_seconds": 0.07,
-                    },
-                    {
-                        "track": "kg",
-                        "version": "heldout-v1",
-                        "dataset": "d1",
-                        "entity_type": "predicate",
-                        "method": "chargram",
-                        "hyperparameters": '{"cfg":"chargram"}',
-                        "gold_count": 1,
-                        "target_pool_size": 20,
-                        "retained_candidate_size": 5,
-                        "candidate_reduction_ratio": 0.75,
-                        "recall_at_1": 0.25,
-                        "recall_at_50": 0.52,
-                        "mrr": 0.45,
-                        "runtime_seconds": 0.05,
-                    },
-                    {
-                        "track": "kg",
-                        "version": "heldout-v1",
-                        "dataset": "d2",
-                        "entity_type": "predicate",
-                        "method": "chargram",
-                        "hyperparameters": '{"cfg":"chargram"}',
-                        "gold_count": 1,
-                        "target_pool_size": 10,
-                        "retained_candidate_size": 4,
-                        "candidate_reduction_ratio": 0.60,
-                        "recall_at_1": 0.25,
-                        "recall_at_50": 0.68,
-                        "mrr": 0.57,
-                        "runtime_seconds": 0.05,
-                    },
-                    {
-                        "track": "kg",
-                        "version": "heldout-v1",
-                        "dataset": "d1",
-                        "entity_type": "instance",
-                        "method": "chargram",
-                        "hyperparameters": '{"cfg":"chargram"}',
-                        "gold_count": 1,
-                        "target_pool_size": 200,
-                        "retained_candidate_size": 50,
-                        "candidate_reduction_ratio": 0.75,
-                        "recall_at_1": 0.12,
-                        "recall_at_50": 0.38,
-                        "mrr": 0.31,
-                        "runtime_seconds": 0.09,
-                    },
-                    {
-                        "track": "kg",
-                        "version": "heldout-v1",
-                        "dataset": "d2",
-                        "entity_type": "instance",
-                        "method": "chargram",
-                        "hyperparameters": '{"cfg":"chargram"}',
-                        "gold_count": 20,
-                        "target_pool_size": 150,
-                        "retained_candidate_size": 50,
-                        "candidate_reduction_ratio": 2.0 / 3.0,
-                        "recall_at_1": 0.42,
-                        "recall_at_50": 0.62,
-                        "mrr": 0.52,
-                        "runtime_seconds": 0.11,
-                    },
-                ]
-            )
+                    }
+                )
+                extra_rows.append(char_ngram_row)
+
+            rows.extend(extra_rows)
 
         with path.open("w", encoding="utf-8", newline="") as csv_file:
             writer = csv.DictWriter(csv_file, fieldnames=list(rows[0].keys()))
@@ -362,6 +299,8 @@ class KgHeldoutReportingTests(unittest.TestCase):
                 "kg_heldout_macro_summary",
                 "kg_heldout_micro_summary",
                 "kg_heldout_reduction_effectiveness",
+                "kg_heldout_pairwise_by_type_inference",
+                "kg_heldout_pairwise_overall_inference",
                 "kg_heldout_interpretation_scaffold",
                 "kg_heldout_transfer_summary",
                 "manifest",
@@ -374,6 +313,9 @@ class KgHeldoutReportingTests(unittest.TestCase):
                     Path(artifacts[key]).read_text(encoding="utf-8"),
                     Path(second_artifacts[key]).read_text(encoding="utf-8"),
                 )
+
+            manifest_text = Path(artifacts["manifest"]).read_text(encoding="utf-8")
+            self.assertNotIn("generated_at=", manifest_text)
 
     def test_grouping_macro_micro_and_transfer_values(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -443,24 +385,27 @@ class KgHeldoutReportingTests(unittest.TestCase):
 
             with Path(artifacts["kg_heldout_by_type_summary"]).open(encoding="utf-8") as csv_file:
                 by_type_rows = list(csv.DictReader(csv_file))
-            self.assertIn("chargram", {row["method"] for row in by_type_rows})
+            self.assertIn("exact_match", {row["method"] for row in by_type_rows})
+            self.assertIn("char_ngram", {row["method"] for row in by_type_rows})
 
             with Path(artifacts["kg_heldout_macro_summary"]).open(encoding="utf-8") as csv_file:
                 macro_rows = list(csv.DictReader(csv_file))
-            self.assertIn("chargram", {row["method"] for row in macro_rows})
+            self.assertIn("exact_match", {row["method"] for row in macro_rows})
+            self.assertIn("char_ngram", {row["method"] for row in macro_rows})
             self.assertIn("delta_tfidf_minus_bm25", {row["method"] for row in macro_rows})
 
             with Path(artifacts["kg_heldout_micro_summary"]).open(encoding="utf-8") as csv_file:
                 micro_rows = list(csv.DictReader(csv_file))
-            self.assertIn("chargram", {row["method"] for row in micro_rows})
+            self.assertIn("exact_match", {row["method"] for row in micro_rows})
+            self.assertIn("char_ngram", {row["method"] for row in micro_rows})
 
             with Path(artifacts["kg_heldout_reduction_effectiveness"]).open(
                 encoding="utf-8"
             ) as csv_file:
                 reduction_rows = list(csv.DictReader(csv_file))
-            chargram_row = next(row for row in reduction_rows if row["method"] == "chargram")
-            self.assertEqual(chargram_row["other_method"], "")
-            self.assertEqual(chargram_row["mrr_delta_vs_other_method"], "")
+            char_ngram_row = next(row for row in reduction_rows if row["method"] == "char_ngram")
+            self.assertEqual(char_ngram_row["other_method"], "")
+            self.assertEqual(char_ngram_row["mrr_delta_vs_other_method"], "")
 
     def test_reduction_effectiveness_includes_per_pair_deltas(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -488,6 +433,150 @@ class KgHeldoutReportingTests(unittest.TestCase):
             self.assertAlmostEqual(float(tfidf_class["recall_at_50_delta_vs_other_method"]), 0.05)
             self.assertAlmostEqual(
                 float(tfidf_class["candidate_reduction_ratio_delta_vs_other_method"]), 0.0
+            )
+
+    def test_pairwise_inference_artifacts_include_expected_values(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            results_csv = tmp / "heldout_result_fixture.csv"
+            self._write_results_csv(results_csv, include_extra_method=True)
+
+            artifacts = generate_kg_heldout_reporting(
+                results_csv_path=results_csv,
+                output_dir=tmp / "comparisons",
+            )
+
+            with Path(artifacts["kg_heldout_pairwise_by_type_inference"]).open(
+                encoding="utf-8"
+            ) as csv_file:
+                by_type_rows = list(csv.DictReader(csv_file))
+            class_tfidf_vs_bm25 = next(
+                row
+                for row in by_type_rows
+                if row["entity_type"] == "class"
+                and row["metric"] == "mrr"
+                and row["method_a"] == "tfidf"
+                and row["method_b"] == "bm25"
+            )
+            self.assertAlmostEqual(float(class_tfidf_vs_bm25["paired_delta"]), 0.10)
+            self.assertAlmostEqual(float(class_tfidf_vs_bm25["method_a_mean"]), 0.80)
+            self.assertAlmostEqual(float(class_tfidf_vs_bm25["method_b_mean"]), 0.70)
+            self.assertAlmostEqual(float(class_tfidf_vs_bm25["ci_lower"]), 0.10)
+            self.assertAlmostEqual(float(class_tfidf_vs_bm25["ci_upper"]), 0.10)
+            self.assertAlmostEqual(float(class_tfidf_vs_bm25["p_value"]), 0.50)
+
+            metrics = {row["metric"] for row in by_type_rows}
+            self.assertEqual(metrics, {"mrr", "recall_at_1", "recall_at_50"})
+
+            with Path(artifacts["kg_heldout_pairwise_overall_inference"]).open(
+                encoding="utf-8"
+            ) as csv_file:
+                overall_rows = list(csv.DictReader(csv_file))
+            self.assertIn(
+                "overall_dataset_type_rows",
+                {row["aggregation_scope"] for row in overall_rows},
+            )
+            self.assertIn(
+                "macro_entity_type_means",
+                {row["aggregation_scope"] for row in overall_rows},
+            )
+            self.assertNotIn(
+                "candidate_reduction_ratio",
+                {row["metric"] for row in overall_rows},
+            )
+
+    def test_inference_helpers_are_deterministic_and_exact(self) -> None:
+        ci_first = paired_bootstrap_confidence_interval([0.1, 0.1])
+        ci_second = paired_bootstrap_confidence_interval([0.1, 0.1])
+        self.assertEqual(ci_first, ci_second)
+        self.assertAlmostEqual(ci_first[0], 0.1)
+        self.assertAlmostEqual(ci_first[1], 0.1)
+        self.assertAlmostEqual(exact_paired_sign_flip_p_value([0.1, 0.1]), 0.5)
+        self.assertAlmostEqual(exact_paired_sign_flip_p_value([0.0, 0.0]), 1.0)
+
+    def test_sign_flip_monte_carlo_fallback_is_deterministic(self) -> None:
+        deltas = [0.5, -0.1, 0.3, -0.2, 0.4, -0.05]
+        p_first = paired_sign_flip_p_value(
+            deltas,
+            exact_max_nonzero=2,
+            monte_carlo_draws=50_000,
+            seed=1729,
+        )
+        p_second = paired_sign_flip_p_value(
+            deltas,
+            exact_max_nonzero=2,
+            monte_carlo_draws=50_000,
+            seed=1729,
+        )
+        self.assertAlmostEqual(p_first, p_second)
+        self.assertGreaterEqual(p_first, 0.0)
+        self.assertLessEqual(p_first, 1.0)
+
+    def test_single_method_reporting_keeps_pairwise_artifacts_empty_but_valid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            results_csv = tmp / "heldout_result_fixture.csv"
+            self._write_results_csv(results_csv)
+
+            with results_csv.open(encoding="utf-8") as csv_file:
+                rows = list(csv.DictReader(csv_file))
+            tfidf_only = [row for row in rows if row["method"] == "tfidf"]
+            with results_csv.open("w", encoding="utf-8", newline="") as csv_file:
+                writer = csv.DictWriter(csv_file, fieldnames=list(tfidf_only[0].keys()))
+                writer.writeheader()
+                writer.writerows(tfidf_only)
+
+            artifacts = generate_kg_heldout_reporting(
+                results_csv_path=results_csv,
+                output_dir=tmp / "comparisons",
+            )
+
+            pairwise_by_type_path = Path(artifacts["kg_heldout_pairwise_by_type_inference"])
+            with pairwise_by_type_path.open(encoding="utf-8") as csv_file:
+                by_type_headers = next(csv.reader(csv_file))
+            with pairwise_by_type_path.open(encoding="utf-8") as csv_file:
+                by_type_rows = list(csv.DictReader(csv_file))
+            self.assertEqual(by_type_rows, [])
+            self.assertEqual(
+                by_type_headers,
+                [
+                    "entity_type",
+                    "metric",
+                    "method_a",
+                    "method_b",
+                    "paired_unit_count",
+                    "nonzero_delta_count",
+                    "method_a_mean",
+                    "method_b_mean",
+                    "paired_delta",
+                    "ci_lower",
+                    "ci_upper",
+                    "p_value",
+                ],
+            )
+
+            pairwise_overall_path = Path(artifacts["kg_heldout_pairwise_overall_inference"])
+            with pairwise_overall_path.open(encoding="utf-8") as csv_file:
+                overall_headers = next(csv.reader(csv_file))
+            with pairwise_overall_path.open(encoding="utf-8") as csv_file:
+                overall_rows = list(csv.DictReader(csv_file))
+            self.assertEqual(overall_rows, [])
+            self.assertEqual(
+                overall_headers,
+                [
+                    "aggregation_scope",
+                    "metric",
+                    "method_a",
+                    "method_b",
+                    "paired_unit_count",
+                    "nonzero_delta_count",
+                    "method_a_mean",
+                    "method_b_mean",
+                    "paired_delta",
+                    "ci_lower",
+                    "ci_upper",
+                    "p_value",
+                ],
             )
 
     def test_skips_transfer_summary_when_auto_detection_is_unavailable(self) -> None:


### PR DESCRIPTION
## Summary
- add deterministic held-out inference utilities for paired bootstrap confidence intervals and paired sign-flip p-values
- extend `report-heldout-kg` with method-agnostic pairwise inference artifacts by entity type and overall
- keep `candidate_reduction_ratio` descriptive-only and add interpretation scaffold guidance for inference outputs
- make reporting artifacts stable for one-method inputs and deterministic across identical runs
- use a hybrid sign-flip strategy: exact for small paired sample sizes and deterministic Monte Carlo fallback for larger sizes

## Testing
- ./venv/bin/python3.12 -m py_compile src/analysis/heldout_inference.py src/analysis/kg_heldout_reporting.py tests/test_kg_heldout_reporting.py
- ./venv/bin/python3.12 -m unittest tests.test_kg_heldout_reporting tests.test_main_cli -v

Closes #46
