### PR TITLE
Issue #47: add deterministic held-out query-level error analysis pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,8 +564,20 @@ Generated files:
 - `kg_heldout_reduction_effectiveness.csv`
 - `kg_heldout_pairwise_by_type_inference.csv`
 - `kg_heldout_pairwise_overall_inference.csv`
+- `kg_heldout_error_cases.csv`
+- `kg_heldout_error_by_type_summary.csv`
+- `kg_heldout_error_interpretation.md`
 - `kg_heldout_interpretation_scaffold.md`
 - `kg_heldout_transfer_summary.csv` when a compatible selected-settings artifact is available
+
+Query-level error-analysis notes:
+
+- `run-heldout-kg` writes a paired query-level CSV (`heldout_query_result_*.csv`).
+- `report-heldout-kg` consumes that file automatically (or via `--query-level-csv`).
+- Retrieval bands are fixed as:
+  - `strong`: gold rank `1..10`
+  - `weak`: gold rank `11..50`
+  - `missed`: not retrieved within `k_max`
 
 Inferential testing design:
 

--- a/src/analysis/kg_heldout_reporting.py
+++ b/src/analysis/kg_heldout_reporting.py
@@ -33,6 +33,22 @@ REQUIRED_COLUMNS = {
     "runtime_seconds",
 }
 REQUIRED_ENTITY_TYPES = {"class", "predicate", "instance"}
+RETRIEVAL_BANDS = ("strong", "weak", "missed")
+REQUIRED_QUERY_COLUMNS = {
+    "track",
+    "version",
+    "dataset",
+    "entity_type",
+    "method",
+    "hyperparameters",
+    "source_entity",
+    "source_label",
+    "gold_target",
+    "gold_target_label",
+    "gold_rank",
+    "retrieved_in_top_kmax",
+    "retrieval_band",
+}
 
 
 class KgHeldoutReportingValidationError(ValueError):
@@ -53,6 +69,22 @@ def _coerce_float(value: object) -> float:
         if isinstance(scalar_value, (int, float, str)):
             return float(scalar_value)
     raise TypeError(f"Unsupported float value: {value!r}")
+
+
+def _coerce_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        numeric = float(value)
+        if numeric in (0.0, 1.0):
+            return bool(int(numeric))
+        raise ValueError(f"Unsupported boolean numeric value: {value!r}")
+    text = str(value).strip().lower()
+    if text in {"true", "1", "yes", "y"}:
+        return True
+    if text in {"false", "0", "no", "n"}:
+        return False
+    raise ValueError(f"Unsupported boolean value: {value!r}")
 
 
 def _resolve_results_csv(results_csv_path: str | Path | None) -> Path:
@@ -121,6 +153,37 @@ def _resolve_selected_settings_json(
     return None, False
 
 
+def _infer_query_level_csv_path(results_csv: Path) -> Path:
+    stem = results_csv.stem
+    if stem.startswith("heldout_result_"):
+        suffix = stem.removeprefix("heldout_result_")
+        name = f"heldout_query_result_{suffix}.csv"
+    else:
+        name = f"{stem}_query.csv"
+    return results_csv.with_name(name)
+
+
+def _resolve_query_level_csv(
+    *,
+    results_csv: Path,
+    query_level_csv_path: str | Path | None,
+) -> Path:
+    if query_level_csv_path is not None:
+        path = Path(query_level_csv_path).resolve()
+        if not path.exists():
+            raise FileNotFoundError(f"Held-out query-level CSV not found: {path}")
+        return path
+
+    inferred = _infer_query_level_csv_path(results_csv).resolve()
+    if inferred.exists():
+        return inferred
+
+    raise FileNotFoundError(
+        "Could not auto-detect held-out query-level CSV for reporting. "
+        f"Expected paired file: {inferred}. Pass --query-level-csv explicitly."
+    )
+
+
 def _find_recall_columns(frame: pd.DataFrame) -> list[str]:
     recall_columns = [column for column in frame.columns if column.startswith("recall_at_")]
     if not recall_columns:
@@ -128,6 +191,116 @@ def _find_recall_columns(frame: pd.DataFrame) -> list[str]:
             "Held-out KG reporting requires at least one recall_at_<k> column."
         )
     return sorted(recall_columns, key=lambda column: int(column.removeprefix("recall_at_")))
+
+
+def _validate_query_frame(
+    frame: pd.DataFrame,
+    *,
+    methods: list[str],
+    k_max: int,
+) -> pd.DataFrame:
+    missing_columns = sorted(REQUIRED_QUERY_COLUMNS - set(frame.columns))
+    if missing_columns:
+        raise KgHeldoutReportingValidationError(
+            "Missing required held-out query-level column(s): " + ", ".join(missing_columns)
+        )
+
+    validated = frame.copy()
+    for column in (
+        "track",
+        "version",
+        "dataset",
+        "entity_type",
+        "method",
+        "hyperparameters",
+        "source_entity",
+        "source_label",
+        "gold_target",
+        "gold_target_label",
+        "retrieval_band",
+    ):
+        validated[column] = validated[column].astype(str)
+
+    validated["gold_rank"] = validated["gold_rank"].astype(int)
+    try:
+        validated["retrieved_in_top_kmax"] = validated["retrieved_in_top_kmax"].map(_coerce_bool)
+    except ValueError as exc:
+        raise KgHeldoutReportingValidationError(
+            "Held-out query-level CSV contains invalid retrieved_in_top_kmax values."
+        ) from exc
+
+    entity_types = set(validated["entity_type"].unique())
+    if entity_types != REQUIRED_ENTITY_TYPES:
+        raise KgHeldoutReportingValidationError(
+            "Held-out query-level reporting requires exactly these entity types: "
+            + ", ".join(sorted(REQUIRED_ENTITY_TYPES))
+        )
+
+    method_set = set(validated["method"].unique())
+    expected_methods = set(methods)
+    if method_set != expected_methods:
+        raise KgHeldoutReportingValidationError(
+            "Held-out query-level CSV method set must match held-out results CSV method set. "
+            f"Expected {sorted(expected_methods)}, found {sorted(method_set)}."
+        )
+
+    bands = set(validated["retrieval_band"].unique())
+    if not bands.issubset(set(RETRIEVAL_BANDS)):
+        raise KgHeldoutReportingValidationError(
+            "Held-out query-level CSV contains unsupported retrieval_band values."
+        )
+
+    duplicates = (
+        validated.groupby(
+            [
+                "track",
+                "version",
+                "dataset",
+                "entity_type",
+                "method",
+                "source_entity",
+                "gold_target",
+            ]
+        )
+        .size()
+        .reset_index(name="row_count")
+    )
+    duplicated_rows = duplicates[duplicates["row_count"] != 1]
+    if not duplicated_rows.empty:
+        bad = duplicated_rows.iloc[0]
+        raise KgHeldoutReportingValidationError(
+            "Held-out query-level CSV requires exactly one row per "
+            "track/version/dataset/entity_type/method/source_entity/gold_target. "
+            f"Found {int(bad['row_count'])} row(s) for dataset='{bad['dataset']}', "
+            f"entity_type='{bad['entity_type']}', method='{bad['method']}', "
+            f"source_entity='{bad['source_entity']}'."
+        )
+
+    for row in validated.to_dict(orient="records"):
+        gold_rank = int(_coerce_float(row["gold_rank"]))
+        retrieved_in_top_kmax = _coerce_bool(row["retrieved_in_top_kmax"])
+        expected_retrieved = gold_rank > 0 and gold_rank <= k_max
+        if retrieved_in_top_kmax != expected_retrieved:
+            raise KgHeldoutReportingValidationError(
+                "Held-out query-level CSV contains inconsistent retrieved_in_top_kmax values."
+            )
+        if gold_rank <= 0:
+            expected_band = "missed"
+        elif gold_rank <= 10:
+            expected_band = "strong"
+        elif gold_rank <= 50:
+            expected_band = "weak"
+        else:
+            expected_band = "missed"
+        if str(row["retrieval_band"]) != expected_band:
+            raise KgHeldoutReportingValidationError(
+                "Held-out query-level CSV contains retrieval_band values inconsistent with gold_rank."
+            )
+
+    return validated.sort_values(
+        ["track", "dataset", "entity_type", "method", "source_entity"],
+        kind="mergesort",
+    ).reset_index(drop=True)
 
 
 def _validate_results_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, list[str], list[str]]:
@@ -443,6 +616,109 @@ def _build_reduction_effectiveness(
     return enriched.sort_values(
         ["track", "dataset", "entity_type", "method"], kind="mergesort"
     ).reset_index(drop=True)
+
+
+def _build_error_cases(query_frame: pd.DataFrame) -> pd.DataFrame:
+    columns = [
+        "track",
+        "version",
+        "dataset",
+        "entity_type",
+        "method",
+        "hyperparameters",
+        "source_entity",
+        "source_label",
+        "gold_target",
+        "gold_target_label",
+        "gold_rank",
+        "retrieved_in_top_kmax",
+        "retrieval_band",
+    ]
+    return query_frame[columns].copy().sort_values(
+        ["track", "dataset", "entity_type", "method", "source_entity"],
+        kind="mergesort",
+    ).reset_index(drop=True)
+
+
+def _build_error_by_type_summary(
+    error_cases: pd.DataFrame,
+    methods: list[str],
+) -> pd.DataFrame:
+    grouped = (
+        error_cases.groupby(["entity_type", "method", "retrieval_band"], as_index=False)
+        .size()
+        .rename(columns={"size": "query_count"})
+    )
+    totals = (
+        error_cases.groupby(["entity_type", "method"], as_index=False)
+        .size()
+        .rename(columns={"size": "total_queries"})
+    )
+    full_index = pd.MultiIndex.from_product(
+        [sorted(REQUIRED_ENTITY_TYPES), methods, RETRIEVAL_BANDS],
+        names=["entity_type", "method", "retrieval_band"],
+    )
+    full = (
+        grouped.set_index(["entity_type", "method", "retrieval_band"])
+        .reindex(full_index, fill_value=0)
+        .reset_index()
+    )
+    merged = full.merge(
+        totals,
+        on=["entity_type", "method"],
+        how="left",
+    )
+    merged["total_queries"] = merged["total_queries"].fillna(0).astype(int)
+    merged["query_count"] = merged["query_count"].astype(int)
+    merged["query_rate"] = merged.apply(
+        lambda row: float(row["query_count"] / row["total_queries"])
+        if int(row["total_queries"]) > 0
+        else 0.0,
+        axis=1,
+    )
+    return merged.sort_values(
+        ["entity_type", "method", "retrieval_band"], kind="mergesort"
+    ).reset_index(drop=True)
+
+
+def _write_error_interpretation(
+    output_path: Path,
+    *,
+    query_level_csv: Path,
+    error_summary: pd.DataFrame,
+    methods: list[str],
+) -> None:
+    lines = [
+        "# KG Held-Out Error Analysis",
+        "",
+        f"- Query-level input CSV: `{query_level_csv}`",
+        "- Retrieval bands: `strong` (rank 1-10), `weak` (rank 11-50), `missed` (not retrieved within k_max).",
+        "",
+    ]
+    for entity_type in sorted(REQUIRED_ENTITY_TYPES):
+        lines.append(f"## {entity_type.capitalize()}")
+        lines.append("")
+        section = error_summary[error_summary["entity_type"] == entity_type].copy()
+        for method in methods:
+            method_rows = section[section["method"] == method].copy()
+            if method_rows.empty:
+                continue
+            ranked = method_rows.sort_values(
+                ["query_count", "retrieval_band"],
+                ascending=[False, True],
+                kind="mergesort",
+            )
+            dominant = ranked.iloc[0]
+            lines.append(
+                f"- `{method}` dominant band: `{dominant['retrieval_band']}` "
+                f"({int(dominant['query_count'])}/{int(dominant['total_queries'])}, {float(dominant['query_rate']):.6f})"
+            )
+            for row in method_rows.itertuples(index=False):
+                lines.append(
+                    f"  - `{row.retrieval_band}`: count `{row.query_count}` rate `{row.query_rate:.6f}`"
+                )
+        lines.append("")
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 def _pairwise_method_pairs(methods: list[str]) -> list[tuple[str, str]]:
@@ -911,11 +1187,19 @@ def generate_kg_heldout_reporting(
     results_csv_path: str | Path | None,
     output_dir: str | Path = "results/comparisons",
     selected_settings_path: str | Path | None = None,
+    query_level_csv_path: str | Path | None = None,
 ) -> dict[str, Path]:
     """Generate held-out KG reporting artifacts."""
     source_csv = _resolve_results_csv(results_csv_path)
     frame = pd.read_csv(source_csv)
     validated, recall_columns, methods = _validate_results_frame(frame)
+    k_max = max(int(column.removeprefix("recall_at_")) for column in recall_columns)
+    query_source_csv = _resolve_query_level_csv(
+        results_csv=source_csv,
+        query_level_csv_path=query_level_csv_path,
+    )
+    query_frame = pd.read_csv(query_source_csv)
+    validated_query = _validate_query_frame(query_frame, methods=methods, k_max=k_max)
     heldout_datasets = set(validated["dataset"].unique())
 
     by_type_summary = _build_by_type_summary(validated, recall_columns, methods)
@@ -928,6 +1212,8 @@ def generate_kg_heldout_reporting(
     pairwise_overall_inference = _build_pairwise_overall_inference(
         validated, recall_columns, methods
     )
+    error_cases = _build_error_cases(validated_query)
+    error_by_type_summary = _build_error_by_type_summary(error_cases, methods)
 
     selected_settings_json, selected_settings_explicit = _resolve_selected_settings_json(
         selected_settings_path,
@@ -954,6 +1240,9 @@ def generate_kg_heldout_reporting(
     reduction_path = output_root / "kg_heldout_reduction_effectiveness.csv"
     pairwise_by_type_path = output_root / "kg_heldout_pairwise_by_type_inference.csv"
     pairwise_overall_path = output_root / "kg_heldout_pairwise_overall_inference.csv"
+    error_cases_path = output_root / "kg_heldout_error_cases.csv"
+    error_summary_path = output_root / "kg_heldout_error_by_type_summary.csv"
+    error_interpretation_path = output_root / "kg_heldout_error_interpretation.md"
     interpretation_path = output_root / "kg_heldout_interpretation_scaffold.md"
     transfer_path = output_root / "kg_heldout_transfer_summary.csv"
     manifest_path = output_root / "manifest.txt"
@@ -964,6 +1253,8 @@ def generate_kg_heldout_reporting(
     reduction_effectiveness.to_csv(reduction_path, index=False, quoting=csv.QUOTE_MINIMAL)
     pairwise_by_type_inference.to_csv(pairwise_by_type_path, index=False)
     pairwise_overall_inference.to_csv(pairwise_overall_path, index=False)
+    error_cases.to_csv(error_cases_path, index=False, quoting=csv.QUOTE_MINIMAL)
+    error_by_type_summary.to_csv(error_summary_path, index=False)
     if transfer_summary is not None:
         transfer_summary.to_csv(transfer_path, index=False)
 
@@ -982,9 +1273,16 @@ def generate_kg_heldout_reporting(
         transfer_note=transfer_note,
         methods=methods,
     )
+    _write_error_interpretation(
+        error_interpretation_path,
+        query_level_csv=query_source_csv,
+        error_summary=error_by_type_summary,
+        methods=methods,
+    )
 
     manifest_lines = [
         f"source_csv={source_csv}",
+        f"query_level_csv={query_source_csv}",
         f"output_dir={output_root}",
         f"selected_settings_json={selected_settings_json}" if selected_settings_json is not None else "selected_settings_json=",
     ]
@@ -992,6 +1290,7 @@ def generate_kg_heldout_reporting(
 
     artifacts: dict[str, Path] = {
         "source_csv": source_csv,
+        "query_level_csv": query_source_csv,
         "output_dir": output_root,
         "kg_heldout_by_type_summary": by_type_path,
         "kg_heldout_macro_summary": macro_path,
@@ -999,6 +1298,9 @@ def generate_kg_heldout_reporting(
         "kg_heldout_reduction_effectiveness": reduction_path,
         "kg_heldout_pairwise_by_type_inference": pairwise_by_type_path,
         "kg_heldout_pairwise_overall_inference": pairwise_overall_path,
+        "kg_heldout_error_cases": error_cases_path,
+        "kg_heldout_error_by_type_summary": error_summary_path,
+        "kg_heldout_error_interpretation": error_interpretation_path,
         "kg_heldout_interpretation_scaffold": interpretation_path,
         "manifest": manifest_path,
     }

--- a/src/experiments/heldout_kg_runner.py
+++ b/src/experiments/heldout_kg_runner.py
@@ -56,6 +56,22 @@ FIXED_CSV_COLUMNS: tuple[str, ...] = (
     "runtime_seconds",
 )
 
+QUERY_CSV_COLUMNS: tuple[str, ...] = (
+    "track",
+    "version",
+    "dataset",
+    "entity_type",
+    "method",
+    "hyperparameters",
+    "source_entity",
+    "source_label",
+    "gold_target",
+    "gold_target_label",
+    "gold_rank",
+    "retrieved_in_top_kmax",
+    "retrieval_band",
+)
+
 
 class HeldoutKgRunnerValidationError(ValueError):
     """Raised when held-out KG execution inputs are invalid."""
@@ -75,6 +91,22 @@ class HeldoutKgResultRecord(TypedDict):
     recalls: dict[int, float]
     mrr: float
     runtime_seconds: float
+
+
+class HeldoutKgQueryRecord(TypedDict):
+    track: str
+    version: str
+    dataset_name: str
+    entity_type: str
+    model: str
+    hyperparameters: dict[str, object]
+    source_entity: str
+    source_label: str
+    gold_target: str
+    gold_target_label: str
+    gold_rank: int
+    retrieved_in_top_kmax: bool
+    retrieval_band: str
 
 
 @dataclass(frozen=True)
@@ -102,6 +134,16 @@ def _default_output_csv_path() -> Path:
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     git_sha = _get_git_short_sha()
     return Path("results") / f"heldout_result_{timestamp}_{git_sha}.csv"
+
+
+def _query_output_csv_path(results_output_csv_path: Path) -> Path:
+    stem = results_output_csv_path.stem
+    if stem.startswith("heldout_result_"):
+        suffix = stem.removeprefix("heldout_result_")
+        query_name = f"heldout_query_result_{suffix}.csv"
+    else:
+        query_name = f"{stem}_query.csv"
+    return results_output_csv_path.with_name(query_name)
 
 
 def _resolve_selected_settings_json(
@@ -337,6 +379,67 @@ def _persist_results_to_csv(
             writer.writerow(row)
 
 
+def _persist_query_results_to_csv(
+    query_results: list[HeldoutKgQueryRecord],
+    output_csv_path: str | Path,
+) -> None:
+    ordered_query_results = sorted(
+        query_results,
+        key=lambda record: (
+            record["track"],
+            record["dataset_name"],
+            record["entity_type"],
+            record["model"],
+            record["source_entity"],
+        ),
+    )
+    output_path = Path(output_csv_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with output_path.open("w", encoding="utf-8", newline="") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=list(QUERY_CSV_COLUMNS))
+        writer.writeheader()
+        for record in ordered_query_results:
+            row: dict[str, object] = {
+                "track": record["track"],
+                "version": record["version"],
+                "dataset": record["dataset_name"],
+                "entity_type": record["entity_type"],
+                "method": record["model"],
+                "hyperparameters": json.dumps(
+                    record["hyperparameters"], sort_keys=True, separators=(",", ":")
+                ),
+                "source_entity": record["source_entity"],
+                "source_label": record["source_label"],
+                "gold_target": record["gold_target"],
+                "gold_target_label": record["gold_target_label"],
+                "gold_rank": record["gold_rank"],
+                "retrieved_in_top_kmax": record["retrieved_in_top_kmax"],
+                "retrieval_band": record["retrieval_band"],
+            }
+            writer.writerow(row)
+
+
+def _gold_rank(
+    ranked_candidates: list[tuple[str, float]],
+    gold_target: str,
+) -> int:
+    for rank, (target_id, _score) in enumerate(ranked_candidates, start=1):
+        if target_id == gold_target:
+            return rank
+    return 0
+
+
+def _retrieval_band(gold_rank: int) -> str:
+    if gold_rank <= 0:
+        return "missed"
+    if gold_rank <= 10:
+        return "strong"
+    if gold_rank <= 50:
+        return "weak"
+    return "missed"
+
+
 def _entity_values(partitions: TypedEntityPartitions, entity_type: EntityType) -> tuple[str, ...]:
     if entity_type is EntityType.CLASS:
         return partitions.classes
@@ -405,7 +508,9 @@ def run_heldout_kg_experiments(
         progress_enabled,
     )
 
+    query_output_csv_path = _query_output_csv_path(resolved_output_csv_path)
     results: list[HeldoutKgResultRecord] = []
+    query_results: list[HeldoutKgQueryRecord] = []
     dataset_names = list(datasets.keys())
     dataset_iterator = tqdm(
         dataset_names,
@@ -453,6 +558,7 @@ def run_heldout_kg_experiments(
             target_labels = _build_labels(target_store, target_entities)
             source_labels = _build_labels(source_store, eval_sources)
             source_label_map = dict(zip(eval_sources, source_labels, strict=True))
+            target_label_map = dict(zip(target_entities, target_labels, strict=True))
             target_tokens, target_labels_preprocessed = _preprocess_labels(target_labels)
             source_tokens, source_labels_preprocessed = _preprocess_labels(source_labels)
             source_label_preprocessed_map = dict(
@@ -529,6 +635,28 @@ def run_heldout_kg_experiments(
                     mrr,
                     results[-1]["runtime_seconds"],
                 )
+
+                for source_id in eval_sources:
+                    gold_target = gold[source_id]
+                    ranked = predictions.get(source_id, [])
+                    gold_rank = _gold_rank(ranked, gold_target)
+                    query_results.append(
+                        HeldoutKgQueryRecord(
+                            track=dataset.track,
+                            version=dataset.version,
+                            dataset_name=dataset.name,
+                            entity_type=entity_type.value,
+                            model=method_name,
+                            hyperparameters=hyperparameters,
+                            source_entity=source_id,
+                            source_label=source_label_map[source_id],
+                            gold_target=gold_target,
+                            gold_target_label=target_label_map.get(gold_target, ""),
+                            gold_rank=gold_rank,
+                            retrieved_in_top_kmax=(gold_rank > 0 and gold_rank <= k_max),
+                            retrieval_band=_retrieval_band(gold_rank),
+                        )
+                    )
         logger.info("Finished held-out dataset '%s'", dataset_name)
 
     _persist_results_to_csv(
@@ -536,10 +664,19 @@ def run_heldout_kg_experiments(
         output_csv_path=resolved_output_csv_path,
         evaluation_ks=evaluation_ks,
     )
+    _persist_query_results_to_csv(
+        query_results,
+        output_csv_path=query_output_csv_path,
+    )
     logger.info(
         "Persisted %d held-out KG result record(s) to %s",
         len(results),
         resolved_output_csv_path,
+    )
+    logger.info(
+        "Persisted %d held-out KG query-level record(s) to %s",
+        len(query_results),
+        query_output_csv_path,
     )
     logger.info("Held-out KG run finished with %d result record(s)", len(results))
     return results

--- a/src/main.py
+++ b/src/main.py
@@ -47,6 +47,7 @@ def generate_kg_heldout_reporting(
     results_csv_path: str | Path | None,
     output_dir: str | Path,
     selected_settings_path: str | Path | None,
+    query_level_csv_path: str | Path | None,
 ) -> dict[str, Path]:
     from src.analysis.kg_heldout_reporting import generate_kg_heldout_reporting as _impl
 
@@ -54,6 +55,7 @@ def generate_kg_heldout_reporting(
         results_csv_path=results_csv_path,
         output_dir=output_dir,
         selected_settings_path=selected_settings_path,
+        query_level_csv_path=query_level_csv_path,
     )
 
 
@@ -241,6 +243,14 @@ def _build_report_heldout_kg_parser(parser: argparse.ArgumentParser) -> None:
         help=(
             "Path to heldout_selected_settings.json. If omitted, the latest "
             "results/comparisons/**/heldout_selected_settings.json is used when available."
+        ),
+    )
+    parser.add_argument(
+        "--query-level-csv",
+        default=None,
+        help=(
+            "Path to held-out query-level CSV. If omitted, a paired heldout_query_result_* file "
+            "is auto-detected from the held-out results CSV."
         ),
     )
     parser.add_argument(
@@ -456,6 +466,17 @@ def _resolve_new_heldout_result_file(
     return new_files[-1]
 
 
+def _infer_query_csv_from_results_csv(results_csv_path: str | Path) -> Path:
+    path = Path(results_csv_path).resolve()
+    stem = path.stem
+    if stem.startswith("heldout_result_"):
+        suffix = stem.removeprefix("heldout_result_")
+        name = f"heldout_query_result_{suffix}.csv"
+    else:
+        name = f"{stem}_query.csv"
+    return path.with_name(name)
+
+
 def _run_experiment_cli(args: argparse.Namespace) -> int:
     show_progress = _resolve_show_progress(args)
     existing_files = _collect_existing_result_files() if args.output_csv_path is None else set()
@@ -549,6 +570,7 @@ def _run_report_heldout_kg_cli(args: argparse.Namespace) -> int:
         results_csv_path=args.results_csv,
         output_dir=args.output_dir,
         selected_settings_path=args.selected_settings_json,
+        query_level_csv_path=args.query_level_csv,
     )
     print(f"Held-Out KG Report Dir: {artifacts['output_dir']}")
     return 0
@@ -576,7 +598,13 @@ def _run_heldout_kg_cli(args: argparse.Namespace) -> int:
         raise FileNotFoundError(
             f"Expected held-out output CSV was not created: {final_output_path}"
         )
+    query_output_path = _infer_query_csv_from_results_csv(final_output_path)
+    if not query_output_path.exists():
+        raise FileNotFoundError(
+            f"Expected held-out query-level CSV was not created: {query_output_path}"
+        )
     print(f"Held-Out KG Results CSV: {final_output_path}")
+    print(f"Held-Out KG Query CSV: {query_output_path}")
     return 0
 
 
@@ -631,6 +659,7 @@ def _run_heldout_full_run_cli(args: argparse.Namespace) -> int:
 
     selected_settings_path: Path
     heldout_results_csv: Path
+    query_level_csv: Path
     development_results_csv: Path | None = None
     report_output_dir: Path | None = None
     caught_exc: Exception | None = None
@@ -666,6 +695,11 @@ def _run_heldout_full_run_cli(args: argparse.Namespace) -> int:
                 args.heldout_results_csv,
                 label="Held-out results CSV",
             )
+            query_level_csv = _infer_query_csv_from_results_csv(heldout_results_csv)
+            if not query_level_csv.exists():
+                raise FileNotFoundError(
+                    f"Held-out query-level CSV not found for provided held-out results CSV: {query_level_csv}"
+                )
             stage_status["run_heldout_kg"] = "skipped"
         else:
             logger.info(
@@ -696,6 +730,11 @@ def _run_heldout_full_run_cli(args: argparse.Namespace) -> int:
                 raise FileNotFoundError(
                     f"Expected held-out output CSV was not created: {heldout_results_csv}"
                 )
+            query_level_csv = _infer_query_csv_from_results_csv(heldout_results_csv)
+            if not query_level_csv.exists():
+                raise FileNotFoundError(
+                    f"Expected held-out query-level CSV was not created: {query_level_csv}"
+                )
             stage_status["run_heldout_kg"] = "success"
             logger.info("Completed heldout-full-run stage=%s", "run_heldout_kg")
 
@@ -710,6 +749,7 @@ def _run_heldout_full_run_cli(args: argparse.Namespace) -> int:
             results_csv_path=heldout_results_csv,
             output_dir=args.output_dir,
             selected_settings_path=selected_settings_path,
+            query_level_csv_path=query_level_csv,
         )
         report_output_dir = Path(report_artifacts["output_dir"]).resolve()
         stage_status["report_heldout_kg"] = "success"
@@ -759,6 +799,7 @@ def _run_heldout_full_run_cli(args: argparse.Namespace) -> int:
                 f"development_results_csv={development_results_csv if development_results_csv is not None else ''}",
                 f"selected_settings_json={selected_settings_path.resolve() if 'selected_settings_path' in locals() else ''}",
                 f"heldout_results_csv={heldout_results_csv.resolve() if 'heldout_results_csv' in locals() else ''}",
+                f"query_level_csv={query_level_csv.resolve() if 'query_level_csv' in locals() else ''}",
                 f"report_output_dir={report_output_dir if report_output_dir is not None else ''}",
                 f"stage_select_heldout_settings={stage_status['select_heldout_settings']}",
                 f"stage_run_heldout_kg={stage_status['run_heldout_kg']}",
@@ -774,6 +815,7 @@ def _run_heldout_full_run_cli(args: argparse.Namespace) -> int:
 
     print(f"Selected Settings JSON: {selected_settings_path}")
     print(f"Held-Out KG Results CSV: {heldout_results_csv}")
+    print(f"Held-Out KG Query CSV: {query_level_csv}")
     print(f"Held-Out KG Report Dir: {report_output_dir}")
     print(f"Held-Out Full Run Manifest: {manifest_path}")
     return 0

--- a/tests/test_heldout_kg_runner.py
+++ b/tests/test_heldout_kg_runner.py
@@ -240,6 +240,8 @@ class HeldoutKgRunnerTests(unittest.TestCase):
 
             self.assertEqual(len(results), 12)
             self.assertTrue(output_csv.exists())
+            query_csv = output_csv.with_name(f"{output_csv.stem}_query.csv")
+            self.assertTrue(query_csv.exists())
             with output_csv.open("r", encoding="utf-8", newline="") as csv_file:
                 reader = csv.DictReader(csv_file)
                 self.assertEqual(
@@ -262,12 +264,46 @@ class HeldoutKgRunnerTests(unittest.TestCase):
                     ],
                 )
                 rows = list(reader)
+            with query_csv.open("r", encoding="utf-8", newline="") as csv_file:
+                query_reader = csv.DictReader(csv_file)
+                self.assertEqual(
+                    query_reader.fieldnames,
+                    [
+                        "track",
+                        "version",
+                        "dataset",
+                        "entity_type",
+                        "method",
+                        "hyperparameters",
+                        "source_entity",
+                        "source_label",
+                        "gold_target",
+                        "gold_target_label",
+                        "gold_rank",
+                        "retrieved_in_top_kmax",
+                        "retrieval_band",
+                    ],
+                )
+                query_rows = list(query_reader)
 
         self.assertEqual(len(rows), 12)
+        self.assertEqual(len(query_rows), 12)
         entity_types = {row["entity_type"] for row in rows}
         methods = {row["method"] for row in rows}
         self.assertEqual(entity_types, {"class", "predicate", "instance"})
         self.assertEqual(methods, {"tfidf", "bm25", "exact_match", "char_ngram"})
+        self.assertEqual({row["retrieval_band"] for row in query_rows}, {"strong"})
+        sort_keys = [
+            (
+                row["track"],
+                row["dataset"],
+                row["entity_type"],
+                row["method"],
+                row["source_entity"],
+            )
+            for row in query_rows
+        ]
+        self.assertEqual(sort_keys, sorted(sort_keys))
 
     def test_runner_uses_frozen_settings_not_grid_search(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -493,3 +529,35 @@ class HeldoutKgRunnerTests(unittest.TestCase):
                 os.chdir(old_cwd)
 
         self.assertEqual(len(results), 12)
+
+    def test_query_rows_capture_ranks_and_bands(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config = self._write_config(tmp)
+            selected = tmp / "heldout_selected_settings.json"
+            output_csv = tmp / "results" / "heldout.csv"
+            self._write_selected_settings(selected)
+
+            run_heldout_kg_experiments(
+                config_path=config,
+                selected_settings_path=selected,
+                output_csv_path=output_csv,
+                show_progress=False,
+            )
+
+            query_csv = output_csv.with_name(f"{output_csv.stem}_query.csv")
+            with query_csv.open("r", encoding="utf-8", newline="") as csv_file:
+                rows = list(csv.DictReader(csv_file))
+
+        self.assertTrue(rows)
+        for row in rows:
+            self.assertIn(row["retrieval_band"], {"strong", "weak", "missed"})
+            rank = int(row["gold_rank"])
+            if row["retrieval_band"] == "strong":
+                self.assertGreater(rank, 0)
+                self.assertLessEqual(rank, 10)
+            if row["retrieval_band"] == "weak":
+                self.assertGreaterEqual(rank, 11)
+                self.assertLessEqual(rank, 50)
+            if row["retrieval_band"] == "missed":
+                self.assertTrue(rank == 0 or rank > 50)

--- a/tests/test_kg_heldout_reporting.py
+++ b/tests/test_kg_heldout_reporting.py
@@ -17,6 +17,15 @@ from src.analysis.kg_heldout_reporting import (
 
 
 class KgHeldoutReportingTests(unittest.TestCase):
+    def _paired_query_csv_path(self, results_csv_path: Path) -> Path:
+        stem = results_csv_path.stem
+        if stem.startswith("heldout_result_"):
+            suffix = stem.removeprefix("heldout_result_")
+            name = f"heldout_query_result_{suffix}.csv"
+        else:
+            name = f"{stem}_query.csv"
+        return results_csv_path.with_name(name)
+
     def _write_results_csv(self, path: Path, *, include_extra_method: bool = False) -> None:
         rows = [
             {
@@ -252,6 +261,63 @@ class KgHeldoutReportingTests(unittest.TestCase):
             writer.writeheader()
             writer.writerows(rows)
 
+        query_rows: list[dict[str, object]] = []
+        rank_by_type = {"class": 1, "predicate": 25, "instance": 0}
+        for row in rows:
+            rank = rank_by_type[str(row["entity_type"])]
+            if rank == 0:
+                band = "missed"
+                retrieved = False
+            elif rank <= 10:
+                band = "strong"
+                retrieved = True
+            elif rank <= 50:
+                band = "weak"
+                retrieved = True
+            else:
+                band = "missed"
+                retrieved = False
+            query_rows.append(
+                {
+                    "track": row["track"],
+                    "version": row["version"],
+                    "dataset": row["dataset"],
+                    "entity_type": row["entity_type"],
+                    "method": row["method"],
+                    "hyperparameters": row["hyperparameters"],
+                    "source_entity": f"urn:source:{row['dataset']}:{row['entity_type']}:{row['method']}",
+                    "source_label": f"source-{row['dataset']}-{row['entity_type']}",
+                    "gold_target": f"urn:target:{row['dataset']}:{row['entity_type']}",
+                    "gold_target_label": f"target-{row['dataset']}-{row['entity_type']}",
+                    "gold_rank": rank,
+                    "retrieved_in_top_kmax": retrieved,
+                    "retrieval_band": band,
+                }
+            )
+
+        query_path = self._paired_query_csv_path(path)
+        with query_path.open("w", encoding="utf-8", newline="") as csv_file:
+            writer = csv.DictWriter(
+                csv_file,
+                fieldnames=[
+                    "track",
+                    "version",
+                    "dataset",
+                    "entity_type",
+                    "method",
+                    "hyperparameters",
+                    "source_entity",
+                    "source_label",
+                    "gold_target",
+                    "gold_target_label",
+                    "gold_rank",
+                    "retrieved_in_top_kmax",
+                    "retrieval_band",
+                ],
+            )
+            writer.writeheader()
+            writer.writerows(query_rows)
+
     def _write_selected_settings(self, path: Path) -> None:
         payload = {
             "heldout_datasets": ["d1", "d2"],
@@ -294,6 +360,7 @@ class KgHeldoutReportingTests(unittest.TestCase):
 
             expected_keys = {
                 "source_csv",
+                "query_level_csv",
                 "output_dir",
                 "kg_heldout_by_type_summary",
                 "kg_heldout_macro_summary",
@@ -301,13 +368,16 @@ class KgHeldoutReportingTests(unittest.TestCase):
                 "kg_heldout_reduction_effectiveness",
                 "kg_heldout_pairwise_by_type_inference",
                 "kg_heldout_pairwise_overall_inference",
+                "kg_heldout_error_cases",
+                "kg_heldout_error_by_type_summary",
+                "kg_heldout_error_interpretation",
                 "kg_heldout_interpretation_scaffold",
                 "kg_heldout_transfer_summary",
                 "manifest",
             }
             self.assertEqual(set(artifacts.keys()), expected_keys)
 
-            stable_keys = expected_keys - {"source_csv", "output_dir", "manifest"}
+            stable_keys = expected_keys - {"source_csv", "query_level_csv", "output_dir", "manifest"}
             for key in stable_keys:
                 self.assertEqual(
                     Path(artifacts[key]).read_text(encoding="utf-8"),
@@ -435,6 +505,133 @@ class KgHeldoutReportingTests(unittest.TestCase):
                 float(tfidf_class["candidate_reduction_ratio_delta_vs_other_method"]), 0.0
             )
 
+    def test_error_artifacts_include_type_method_band_grouping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            results_csv = tmp / "heldout_result_fixture.csv"
+            self._write_results_csv(results_csv, include_extra_method=True)
+
+            artifacts = generate_kg_heldout_reporting(
+                results_csv_path=results_csv,
+                output_dir=tmp / "comparisons",
+            )
+
+            with Path(artifacts["kg_heldout_error_cases"]).open(encoding="utf-8") as csv_file:
+                error_rows = list(csv.DictReader(csv_file))
+            self.assertTrue(error_rows)
+            self.assertEqual(
+                {"strong", "weak", "missed"},
+                {row["retrieval_band"] for row in error_rows},
+            )
+
+            with Path(artifacts["kg_heldout_error_by_type_summary"]).open(
+                encoding="utf-8"
+            ) as csv_file:
+                summary_rows = list(csv.DictReader(csv_file))
+            self.assertTrue(summary_rows)
+            self.assertIn(
+                ("class", "tfidf", "strong"),
+                {
+                    (row["entity_type"], row["method"], row["retrieval_band"])
+                    for row in summary_rows
+                },
+            )
+            class_tfidf_strong = next(
+                row
+                for row in summary_rows
+                if row["entity_type"] == "class"
+                and row["method"] == "tfidf"
+                and row["retrieval_band"] == "strong"
+            )
+            self.assertAlmostEqual(float(class_tfidf_strong["query_rate"]), 1.0)
+
+            interpretation = Path(artifacts["kg_heldout_error_interpretation"]).read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("KG Held-Out Error Analysis", interpretation)
+            self.assertIn("dominant band", interpretation)
+
+    def test_explicit_query_level_csv_is_used(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            results_csv = tmp / "heldout_result_fixture.csv"
+            self._write_results_csv(results_csv)
+            explicit_query_csv = tmp / "custom_query.csv"
+            explicit_query_csv.write_text(
+                self._paired_query_csv_path(results_csv).read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+
+            artifacts = generate_kg_heldout_reporting(
+                results_csv_path=results_csv,
+                output_dir=tmp / "comparisons",
+                query_level_csv_path=explicit_query_csv,
+            )
+
+            self.assertEqual(Path(artifacts["query_level_csv"]), explicit_query_csv.resolve())
+
+    def test_query_validation_rejects_inconsistent_top_k_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            results_csv = tmp / "heldout_result_fixture.csv"
+            self._write_results_csv(results_csv)
+            query_csv = self._paired_query_csv_path(results_csv)
+            with query_csv.open(encoding="utf-8") as csv_file:
+                rows = list(csv.DictReader(csv_file))
+            rows[0]["gold_rank"] = "1"
+            rows[0]["retrieved_in_top_kmax"] = "False"
+            with query_csv.open("w", encoding="utf-8", newline="") as csv_file:
+                writer = csv.DictWriter(csv_file, fieldnames=list(rows[0].keys()))
+                writer.writeheader()
+                writer.writerows(rows)
+
+            with self.assertRaises(KgHeldoutReportingValidationError):
+                generate_kg_heldout_reporting(
+                    results_csv_path=results_csv,
+                    output_dir=tmp / "comparisons",
+                )
+
+    def test_query_validation_rejects_inconsistent_band(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            results_csv = tmp / "heldout_result_fixture.csv"
+            self._write_results_csv(results_csv)
+            query_csv = self._paired_query_csv_path(results_csv)
+            with query_csv.open(encoding="utf-8") as csv_file:
+                rows = list(csv.DictReader(csv_file))
+            rows[0]["gold_rank"] = "1"
+            rows[0]["retrieval_band"] = "weak"
+            with query_csv.open("w", encoding="utf-8", newline="") as csv_file:
+                writer = csv.DictWriter(csv_file, fieldnames=list(rows[0].keys()))
+                writer.writeheader()
+                writer.writerows(rows)
+
+            with self.assertRaises(KgHeldoutReportingValidationError):
+                generate_kg_heldout_reporting(
+                    results_csv_path=results_csv,
+                    output_dir=tmp / "comparisons",
+                )
+
+    def test_query_validation_rejects_duplicate_query_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            results_csv = tmp / "heldout_result_fixture.csv"
+            self._write_results_csv(results_csv)
+            query_csv = self._paired_query_csv_path(results_csv)
+            with query_csv.open(encoding="utf-8") as csv_file:
+                rows = list(csv.DictReader(csv_file))
+            duplicated_rows = rows + [rows[0]]
+            with query_csv.open("w", encoding="utf-8", newline="") as csv_file:
+                writer = csv.DictWriter(csv_file, fieldnames=list(rows[0].keys()))
+                writer.writeheader()
+                writer.writerows(duplicated_rows)
+
+            with self.assertRaises(KgHeldoutReportingValidationError):
+                generate_kg_heldout_reporting(
+                    results_csv_path=results_csv,
+                    output_dir=tmp / "comparisons",
+                )
+
     def test_pairwise_inference_artifacts_include_expected_values(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
@@ -525,6 +722,14 @@ class KgHeldoutReportingTests(unittest.TestCase):
                 writer = csv.DictWriter(csv_file, fieldnames=list(tfidf_only[0].keys()))
                 writer.writeheader()
                 writer.writerows(tfidf_only)
+            query_csv = self._paired_query_csv_path(results_csv)
+            with query_csv.open(encoding="utf-8") as csv_file:
+                query_rows = list(csv.DictReader(csv_file))
+            tfidf_query = [row for row in query_rows if row["method"] == "tfidf"]
+            with query_csv.open("w", encoding="utf-8", newline="") as csv_file:
+                writer = csv.DictWriter(csv_file, fieldnames=list(tfidf_query[0].keys()))
+                writer.writeheader()
+                writer.writerows(tfidf_query)
 
             artifacts = generate_kg_heldout_reporting(
                 results_csv_path=results_csv,

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -469,6 +469,7 @@ heldout:
                 results_csv_path=str(results_csv),
                 output_dir=str(output_dir),
                 selected_settings_path=str(selected_json),
+                query_level_csv_path=None,
             )
             self.assertIn(f"Held-Out KG Report Dir: {output_dir}", stdout.getvalue())
 
@@ -486,6 +487,7 @@ heldout:
             results_csv_path=None,
             output_dir="results/comparisons",
             selected_settings_path=None,
+            query_level_csv_path=None,
         )
         self.assertIn("Held-Out KG Report Dir:", stdout.getvalue())
 
@@ -511,6 +513,7 @@ heldout:
 
             with patch("src.main.run_heldout_kg_experiments", return_value=[]) as heldout_mock:
                 output_csv.write_text("track,version\n", encoding="utf-8")
+                (tmp / "heldout_query.csv").write_text("track,version\n", encoding="utf-8")
                 with contextlib.redirect_stdout(stdout):
                     exit_code = main(
                         [
@@ -532,6 +535,7 @@ heldout:
                 show_progress=None,
             )
             self.assertIn(f"Held-Out KG Results CSV: {output_csv}", stdout.getvalue())
+            self.assertIn("Held-Out KG Query CSV:", stdout.getvalue())
 
     def test_run_heldout_kg_default_selected_settings_and_output(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -544,6 +548,8 @@ heldout:
                     expected_output = tmp / "results" / "heldout_result_20260101_000000_deadbeef.csv"
                     expected_output.parent.mkdir(parents=True, exist_ok=True)
                     expected_output.write_text("track,version\n", encoding="utf-8")
+                    expected_query = expected_output.with_name("heldout_query_result_20260101_000000_deadbeef.csv")
+                    expected_query.write_text("track,version\n", encoding="utf-8")
                     with patch(
                         "src.main._resolve_new_heldout_result_file",
                         return_value=expected_output,
@@ -561,6 +567,7 @@ heldout:
             show_progress=None,
         )
         self.assertIn("Held-Out KG Results CSV:", stdout.getvalue())
+        self.assertIn("Held-Out KG Query CSV:", stdout.getvalue())
 
     def test_run_heldout_kg_failure_path(self) -> None:
         stderr = io.StringIO()
@@ -585,6 +592,10 @@ heldout:
             heldout_csv = tmp / "results" / "heldout_result_fixture.csv"
             heldout_csv.parent.mkdir(parents=True, exist_ok=True)
             heldout_csv.write_text("track,version\n", encoding="utf-8")
+            (tmp / "results" / "heldout_query_result_fixture.csv").write_text(
+                "track,version\n",
+                encoding="utf-8",
+            )
             report_output_dir = tmp / "comparisons" / "heldout_result_fixture"
             report_output_dir.mkdir(parents=True, exist_ok=True)
             stdout = io.StringIO()
@@ -636,6 +647,7 @@ heldout:
                 results_csv_path=heldout_csv.resolve(),
                 output_dir=str(tmp / "comparisons"),
                 selected_settings_path=selected_settings.resolve(),
+                query_level_csv_path=heldout_csv.resolve().with_name("heldout_query_result_fixture.csv"),
             )
 
             manifest_path = report_output_dir / "heldout_full_run_manifest.txt"
@@ -669,6 +681,10 @@ heldout:
             heldout_csv = tmp / "results" / "heldout_result_fixture.csv"
             heldout_csv.parent.mkdir(parents=True, exist_ok=True)
             heldout_csv.write_text("track,version\n", encoding="utf-8")
+            (tmp / "results" / "heldout_query_result_fixture.csv").write_text(
+                "track,version\n",
+                encoding="utf-8",
+            )
             output_root = tmp / "comparisons" / "heldout_result_fixture"
             output_root.mkdir(parents=True, exist_ok=True)
 
@@ -699,6 +715,7 @@ heldout:
                 results_csv_path=heldout_csv.resolve(),
                 output_dir="results/comparisons",
                 selected_settings_path=selected_settings.resolve(),
+                query_level_csv_path=heldout_csv.resolve().with_name("heldout_query_result_fixture.csv"),
             )
             manifest_text = (output_root / "heldout_full_run_manifest.txt").read_text(encoding="utf-8")
             self.assertIn("stage_select_heldout_settings=skipped", manifest_text)
@@ -711,6 +728,8 @@ heldout:
             selected_settings.write_text('{"source_csv": "/tmp/dev.csv"}\n', encoding="utf-8")
             heldout_csv = tmp / "heldout_result_fixture.csv"
             heldout_csv.write_text("track,version\n", encoding="utf-8")
+            query_csv = tmp / "heldout_query_result_fixture.csv"
+            query_csv.write_text("track,version\n", encoding="utf-8")
             output_root = tmp / "comparisons" / "heldout_result_fixture"
             output_root.mkdir(parents=True, exist_ok=True)
 
@@ -741,6 +760,7 @@ heldout:
                 results_csv_path=heldout_csv.resolve(),
                 output_dir="results/comparisons",
                 selected_settings_path=selected_settings.resolve(),
+                query_level_csv_path=query_csv.resolve(),
             )
             manifest_text = (output_root / "heldout_full_run_manifest.txt").read_text(encoding="utf-8")
             self.assertIn("stage_run_heldout_kg=skipped", manifest_text)


### PR DESCRIPTION
## Summary
Implements Issue #47 by adding deterministic query-level held-out error analysis across runner, reporting, CLI wiring, and tests.

## What changed
- Added query-level held-out artifact generation in `run-heldout-kg`:
  - `heldout_query_result_*.csv` (or `<stem>_query.csv`)
  - includes source/gold labels, gold rank, top-k flag, and retrieval band (`strong`/`weak`/`missed`)
- Enforced deterministic query-row ordering in runner output.
- Extended `report-heldout-kg` to consume query-level CSV (auto-detected or `--query-level-csv`) and generate:
  - `kg_heldout_error_cases.csv`
  - `kg_heldout_error_by_type_summary.csv`
  - `kg_heldout_error_interpretation.md`
- Added strict query-level validation:
  - required schema
  - method/type consistency with held-out results
  - boolean coercion robustness
  - rank/flag/band consistency checks
  - duplicate query-row rejection
- Wired `heldout-full-run` to pass same-run query-level artifact into reporting and manifest.
- Updated README with query-level error-analysis artifacts and retrieval-band definitions.

## Validation
- Ran:
  - `python3.12 -m unittest tests.test_heldout_kg_runner tests.test_kg_heldout_reporting tests.test_main_cli`
- Result: all tests passed.

Closing #47