### PR TITLE
Issue #48: add class-only held-out workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,14 @@ heldout_datasets:
     target_rdf: /absolute/path/to/target.rdf
     alignment_rdf: /absolute/path/to/alignment.rdf
 
+heldout_secondary_datasets:
+  <secondary_dataset_name>:
+    track: <track_name>
+    version: "<benchmark_version>"
+    source_rdf: /absolute/path/to/source.rdf
+    target_rdf: /absolute/path/to/target.rdf
+    alignment_rdf: /absolute/path/to/alignment.rdf
+
 heldout:
   selection:
     metric: mrr
@@ -208,6 +216,9 @@ Config semantics and validation:
 - `development_datasets.<name>` and `heldout_datasets.<name>`:
   - requires `track`, `version`, `source_rdf`, `target_rdf`, `alignment_rdf`
   - RDF/alignment file paths are validated for existence before run starts
+- `heldout_secondary_datasets.<name>`:
+  - requires `track`, `version`, `source_rdf`, `target_rdf`, `alignment_rdf`
+  - validates the same path existence checks as other dataset groups
 - `heldout.selection`:
   - currently fixed to `metric=mrr`, `lambda=0.5`, `weighting=equal_track_weight`, `ranking=per_track_normalized_rank`
   - used to document and validate the frozen held-out selection policy
@@ -617,6 +628,30 @@ python -m src.main heldout-full-run --config-path config/runtime.yaml --selected
 Generated provenance file:
 
 - `heldout_full_run_manifest.txt`
+
+## Secondary Class-Only Held-Out Workflow
+
+Use this secondary workflow to evaluate class-only held-out datasets while keeping
+KG typed held-out evaluation as the primary protocol.
+
+Class-only full run:
+
+```bash
+python -m src.main heldout-class-full-run --config-path config/runtime.yaml --dev-results-csv results/result_YYYYMMDD_HHMMSS_<gitsha>.csv
+```
+
+Manual class-only workflow:
+
+```bash
+python -m src.main select-heldout-settings --results-csv results/result_YYYYMMDD_HHMMSS_<gitsha>.csv --config-path config/runtime.yaml
+python -m src.main run-heldout-class --config-path config/runtime.yaml --selected-settings-json results/comparisons/result_YYYYMMDD_HHMMSS_<gitsha>/heldout_selected_settings.json
+python -m src.main report-heldout-class --results-csv results/heldout_class_result_YYYYMMDD_HHMMSS_<gitsha>.csv --selected-settings-json results/comparisons/result_YYYYMMDD_HHMMSS_<gitsha>/heldout_selected_settings.json --output-dir results/comparisons
+```
+
+Secondary class-only outputs are separate from KG outputs and use the `class_heldout_*`
+artifact namespace. The class-only full run writes:
+
+- `heldout_class_full_run_manifest.txt`
 
 ## Logging
 

--- a/config/runtime.example.yaml
+++ b/config/runtime.example.yaml
@@ -34,6 +34,14 @@ heldout_datasets:
     target_rdf: /Users/.../heldout_target.rdf
     alignment_rdf: /Users/.../heldout_alignment.rdf
 
+heldout_secondary_datasets:
+  class_only_2022_supervised_dataset_1:
+    track: bioml-supervised
+    version: "2022"
+    source_rdf: /Users/.../class_only_supervised_source.rdf
+    target_rdf: /Users/.../class_only_supervised_target.rdf
+    alignment_rdf: /Users/.../class_only_supervised_alignment.rdf
+
 heldout:
   selection:
     metric: mrr

--- a/src/analysis/class_heldout_reporting.py
+++ b/src/analysis/class_heldout_reporting.py
@@ -1,0 +1,681 @@
+"""Reporting utilities for secondary held-out class-only evaluation artifacts."""
+
+from __future__ import annotations
+
+import csv
+from itertools import combinations
+import json
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+from src.analysis.heldout_inference import (
+    paired_bootstrap_confidence_interval,
+    paired_sign_flip_p_value,
+)
+from src.method_registry import (
+    PRIMARY_COMPARISON_METHODS,
+    ordered_method_names,
+    supports_primary_comparison,
+)
+
+logger = logging.getLogger(__name__)
+
+REQUIRED_COLUMNS = {
+    "track",
+    "version",
+    "dataset",
+    "entity_type",
+    "method",
+    "hyperparameters",
+    "gold_count",
+    "target_pool_size",
+    "retained_candidate_size",
+    "candidate_reduction_ratio",
+    "mrr",
+    "runtime_seconds",
+}
+
+
+class ClassHeldoutReportingValidationError(ValueError):
+    """Raised when held-out class-only reporting inputs are invalid."""
+
+
+def _coerce_float(value: object) -> float:
+    if isinstance(value, str):
+        return float(value)
+    if isinstance(value, (int, float)):
+        return float(value)
+    if hasattr(value, "item"):
+        try:
+            scalar_value = value.item()  # type: ignore[call-arg]
+        except (TypeError, ValueError, AttributeError):
+            scalar_value = None
+        if isinstance(scalar_value, (int, float, str)):
+            return float(scalar_value)
+    raise TypeError(f"Unsupported float value: {value!r}")
+
+
+def _resolve_results_csv(results_csv_path: str | Path | None) -> Path:
+    if results_csv_path is not None:
+        path = Path(results_csv_path).resolve()
+        if not path.exists():
+            raise FileNotFoundError(f"Held-out class-only results CSV not found: {path}")
+        return path
+
+    candidates = sorted(
+        Path("results").glob("heldout_class_result_*.csv"),
+        key=lambda candidate: candidate.stat().st_mtime,
+    )
+    if not candidates:
+        raise FileNotFoundError("No results/heldout_class_result_*.csv files found for reporting.")
+    return candidates[-1].resolve()
+
+
+def _resolve_selected_settings_json(
+    selected_settings_path: str | Path | None,
+    *,
+    heldout_datasets: set[str],
+) -> tuple[Path | None, bool]:
+    if selected_settings_path is not None:
+        path = Path(selected_settings_path).resolve()
+        if not path.exists():
+            raise FileNotFoundError(f"Selected settings JSON not found: {path}")
+        return path, True
+
+    candidates = sorted(
+        Path("results/comparisons").glob("**/heldout_selected_settings.json"),
+        key=lambda candidate: candidate.stat().st_mtime,
+    )
+    if not candidates:
+        return None, False
+
+    matching_candidates: list[Path] = []
+    for candidate in candidates:
+        try:
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        candidate_datasets = payload.get("heldout_datasets")
+        if not isinstance(candidate_datasets, list):
+            continue
+        if {str(value) for value in candidate_datasets} == heldout_datasets:
+            matching_candidates.append(candidate.resolve())
+
+    if len(matching_candidates) == 1:
+        return matching_candidates[0], False
+    return None, False
+
+
+def _find_recall_columns(frame: pd.DataFrame) -> list[str]:
+    recall_columns = [column for column in frame.columns if column.startswith("recall_at_")]
+    if not recall_columns:
+        raise ClassHeldoutReportingValidationError(
+            "Held-out class-only reporting requires at least one recall_at_<k> column."
+        )
+    return sorted(recall_columns, key=lambda column: int(column.removeprefix("recall_at_")))
+
+
+def _validate_results_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, list[str], list[str]]:
+    missing_columns = sorted(REQUIRED_COLUMNS - set(frame.columns))
+    if missing_columns:
+        raise ClassHeldoutReportingValidationError(
+            "Missing required held-out reporting column(s): " + ", ".join(missing_columns)
+        )
+
+    validated = frame.copy()
+    for column in ("track", "version", "dataset", "entity_type", "method", "hyperparameters"):
+        validated[column] = validated[column].astype(str)
+
+    if set(validated["entity_type"].unique()) != {"class"}:
+        raise ClassHeldoutReportingValidationError(
+            "Held-out class-only reporting requires class-only rows (entity_type='class')."
+        )
+
+    for column in (
+        "gold_count",
+        "target_pool_size",
+        "retained_candidate_size",
+        "candidate_reduction_ratio",
+        "mrr",
+        "runtime_seconds",
+    ):
+        validated[column] = validated[column].astype(float)
+
+    recall_columns = _find_recall_columns(validated)
+    for column in recall_columns:
+        validated[column] = validated[column].astype(float)
+
+    methods = ordered_method_names(validated["method"].unique())
+    if not methods:
+        raise ClassHeldoutReportingValidationError(
+            "Held-out class-only reporting requires at least one method row."
+        )
+
+    coverage = (
+        validated.groupby(["track", "version", "dataset"])["method"]
+        .nunique()
+        .reset_index(name="method_count")
+    )
+    incomplete = coverage[coverage["method_count"] != len(methods)]
+    if not incomplete.empty:
+        bad = incomplete.iloc[0]
+        raise ClassHeldoutReportingValidationError(
+            "Each secondary held-out dataset must have one row for every reported method. "
+            f"Found incomplete coverage for dataset='{bad['dataset']}'."
+        )
+
+    duplicates = (
+        validated.groupby(["track", "version", "dataset", "method"])
+        .size()
+        .reset_index(name="row_count")
+    )
+    duplicated_rows = duplicates[duplicates["row_count"] != 1]
+    if not duplicated_rows.empty:
+        bad = duplicated_rows.iloc[0]
+        raise ClassHeldoutReportingValidationError(
+            "Held-out class-only reporting requires exactly one row per dataset/method. "
+            f"Found {int(bad['row_count'])} row(s) for dataset='{bad['dataset']}', method='{bad['method']}'."
+        )
+
+    return validated.sort_values(
+        ["track", "dataset", "method"], kind="mergesort"
+    ).reset_index(drop=True), recall_columns, methods
+
+
+def _build_by_method_summary(
+    frame: pd.DataFrame,
+    recall_columns: list[str],
+    methods: list[str],
+) -> pd.DataFrame:
+    aggregation: dict[str, str] = {
+        "dataset": "count",
+        "gold_count": "sum",
+        "target_pool_size": "mean",
+        "retained_candidate_size": "mean",
+        "candidate_reduction_ratio": "mean",
+        "mrr": "mean",
+    }
+    for column in recall_columns:
+        aggregation[column] = "mean"
+
+    summary = (
+        frame.groupby(["method"], as_index=False)
+        .agg(aggregation)
+        .rename(
+            columns={
+                "dataset": "dataset_count",
+                "gold_count": "gold_count_sum",
+                "target_pool_size": "target_pool_size_mean",
+                "retained_candidate_size": "retained_candidate_size_mean",
+                "candidate_reduction_ratio": "candidate_reduction_ratio_mean",
+                "mrr": "mrr_mean",
+                **{column: f"{column}_mean" for column in recall_columns},
+            }
+        )
+    )
+    method_order = {method: index for index, method in enumerate(methods)}
+    summary["_method_order"] = summary["method"].map(
+        lambda value: method_order.get(str(value), len(method_order))
+    )
+    return summary.sort_values(["_method_order", "method"], kind="mergesort").drop(
+        columns="_method_order"
+    ).reset_index(drop=True)
+
+
+def _delta_row(
+    frame: pd.DataFrame,
+    *,
+    value_columns: list[str],
+    method_column: str = "method",
+) -> dict[str, object]:
+    indexed = frame.set_index(method_column)
+    row: dict[str, object] = {method_column: "delta_tfidf_minus_bm25"}
+    for column in value_columns:
+        left = _coerce_float(indexed.loc[PRIMARY_COMPARISON_METHODS[0], column])
+        right = _coerce_float(indexed.loc[PRIMARY_COMPARISON_METHODS[1], column])
+        row[column] = float(left - right)
+    return row
+
+
+def _build_macro_summary(
+    by_method_summary: pd.DataFrame,
+    recall_columns: list[str],
+    methods: list[str],
+) -> pd.DataFrame:
+    value_columns = [
+        "dataset_count",
+        "gold_count_sum",
+        "target_pool_size_mean",
+        "retained_candidate_size_mean",
+        "candidate_reduction_ratio_mean",
+        "mrr_mean",
+        *(f"{column}_mean" for column in recall_columns),
+    ]
+    summary = by_method_summary.copy()
+    summary.insert(1, "type_count", 1)
+    if supports_primary_comparison(methods):
+        summary = pd.concat(
+            [summary, pd.DataFrame([_delta_row(summary, value_columns=value_columns)])],
+            ignore_index=True,
+        )
+    return summary.rename(
+        columns={
+            "dataset_count": "dataset_count_macro_mean",
+            "gold_count_sum": "gold_count_sum_macro_mean",
+        }
+    ).sort_values(["method"], kind="mergesort").reset_index(drop=True)
+
+
+def _weighted_mean(values: pd.Series, weights: pd.Series) -> float:
+    total_weight = float(weights.sum())
+    if total_weight <= 0.0:
+        raise ClassHeldoutReportingValidationError(
+            "Gold-weighted micro-average requires positive total gold_count."
+        )
+    return float((values * weights).sum() / total_weight)
+
+
+def _build_micro_summary(
+    frame: pd.DataFrame,
+    recall_columns: list[str],
+    methods: list[str],
+) -> pd.DataFrame:
+    method_rows: list[dict[str, object]] = []
+    for method in methods:
+        group = frame[frame["method"] == method].sort_values(
+            ["track", "dataset"], kind="mergesort"
+        )
+        weights = group["gold_count"]
+        row: dict[str, object] = {
+            "method": method,
+            "dataset_row_count": int(len(group)),
+            "gold_count_sum": float(group["gold_count"].sum()),
+            "target_pool_size_sum": float(group["target_pool_size"].sum()),
+            "retained_candidate_size_sum": float(group["retained_candidate_size"].sum()),
+            "candidate_reduction_ratio": _weighted_mean(group["candidate_reduction_ratio"], weights),
+            "mrr": _weighted_mean(group["mrr"], weights),
+        }
+        for column in recall_columns:
+            row[column] = _weighted_mean(group[column], weights)
+        method_rows.append(row)
+
+    value_columns = [
+        "dataset_row_count",
+        "gold_count_sum",
+        "target_pool_size_sum",
+        "retained_candidate_size_sum",
+        "candidate_reduction_ratio",
+        "mrr",
+        *recall_columns,
+    ]
+    summary = pd.DataFrame(method_rows)
+    if supports_primary_comparison(methods):
+        summary = pd.concat(
+            [summary, pd.DataFrame([_delta_row(summary, value_columns=value_columns)])],
+            ignore_index=True,
+        )
+    return summary.sort_values(["method"], kind="mergesort").reset_index(drop=True)
+
+
+def _build_reduction_effectiveness(
+    frame: pd.DataFrame,
+    recall_columns: list[str],
+    methods: list[str],
+) -> pd.DataFrame:
+    base_columns = [
+        "track",
+        "version",
+        "dataset",
+        "entity_type",
+        "method",
+        "hyperparameters",
+        "gold_count",
+        "target_pool_size",
+        "retained_candidate_size",
+        "candidate_reduction_ratio",
+        *recall_columns,
+        "mrr",
+        "runtime_seconds",
+    ]
+    enriched = frame[base_columns].copy()
+    if not supports_primary_comparison(methods):
+        return enriched.sort_values(["track", "dataset", "method"], kind="mergesort").reset_index(drop=True)
+
+    primary_pair = frame[frame["method"].isin(PRIMARY_COMPARISON_METHODS)].copy()
+    paired = (
+        primary_pair.pivot(
+            index=["track", "version", "dataset"],
+            columns="method",
+            values=["candidate_reduction_ratio", "mrr", *recall_columns],
+        )
+        .sort_index()
+    )
+    other_method_map = {
+        PRIMARY_COMPARISON_METHODS[0]: PRIMARY_COMPARISON_METHODS[1],
+        PRIMARY_COMPARISON_METHODS[1]: PRIMARY_COMPARISON_METHODS[0],
+    }
+    enriched["other_method"] = enriched["method"].map(other_method_map)
+    for metric in ["candidate_reduction_ratio", "mrr", *recall_columns]:
+        deltas: list[float | None] = []
+        for row in enriched.itertuples(index=False):
+            current_method = str(row.method)
+            if current_method not in other_method_map:
+                deltas.append(None)
+                continue
+            current_value = _coerce_float(paired.loc[(row.track, row.version, row.dataset), (metric, current_method)])
+            other_value = _coerce_float(
+                paired.loc[
+                    (row.track, row.version, row.dataset),
+                    (metric, other_method_map[current_method]),
+                ]
+            )
+            deltas.append(float(current_value - other_value))
+        enriched[f"{metric}_delta_vs_other_method"] = deltas
+    return enriched.sort_values(["track", "dataset", "method"], kind="mergesort").reset_index(drop=True)
+
+
+def _pairwise_method_pairs(methods: list[str]) -> list[tuple[str, str]]:
+    return list(combinations(ordered_method_names(methods), 2))
+
+
+def _build_pairwise_overall_inference(
+    frame: pd.DataFrame,
+    recall_columns: list[str],
+    methods: list[str],
+) -> pd.DataFrame:
+    method_pairs = _pairwise_method_pairs(methods)
+    if not method_pairs:
+        return pd.DataFrame(
+            columns=[
+                "aggregation_scope",
+                "metric",
+                "method_a",
+                "method_b",
+                "paired_unit_count",
+                "nonzero_delta_count",
+                "method_a_mean",
+                "method_b_mean",
+                "paired_delta",
+                "ci_lower",
+                "ci_upper",
+                "p_value",
+            ]
+        )
+
+    rows: list[dict[str, object]] = []
+    metrics = ["mrr", *recall_columns]
+    for metric in metrics:
+        overall_pivot = frame.pivot(
+            index=["track", "version", "dataset"], columns="method", values=metric
+        ).sort_index()
+        track_means = frame.groupby(["track", "method"], as_index=False)[metric].mean(
+            numeric_only=True
+        )
+        macro_track_pivot = track_means.pivot(index="track", columns="method", values=metric).sort_index()
+
+        for method_a, method_b in method_pairs:
+            for scope, pivot in (
+                ("overall_dataset_rows", overall_pivot),
+                ("macro_track_means", macro_track_pivot),
+            ):
+                method_a_values = pivot[method_a].astype(float)
+                method_b_values = pivot[method_b].astype(float)
+                deltas = method_a_values - method_b_values
+                ci_lower, ci_upper = paired_bootstrap_confidence_interval(deltas.tolist())
+                rows.append(
+                    {
+                        "aggregation_scope": scope,
+                        "metric": metric,
+                        "method_a": method_a,
+                        "method_b": method_b,
+                        "paired_unit_count": int(len(pivot)),
+                        "nonzero_delta_count": int((deltas != 0.0).sum()),
+                        "method_a_mean": float(method_a_values.mean()),
+                        "method_b_mean": float(method_b_values.mean()),
+                        "paired_delta": float(deltas.mean()),
+                        "ci_lower": ci_lower,
+                        "ci_upper": ci_upper,
+                        "p_value": paired_sign_flip_p_value(deltas.tolist()),
+                    }
+                )
+
+    method_order = {method: index for index, method in enumerate(methods)}
+    result = pd.DataFrame(rows)
+    result["_method_a_order"] = result["method_a"].map(
+        lambda value: method_order.get(str(value), len(method_order))
+    )
+    result["_method_b_order"] = result["method_b"].map(
+        lambda value: method_order.get(str(value), len(method_order))
+    )
+    return result.sort_values(
+        ["aggregation_scope", "metric", "_method_a_order", "_method_b_order", "method_a", "method_b"],
+        kind="mergesort",
+    ).drop(columns=["_method_a_order", "_method_b_order"]).reset_index(drop=True)
+
+
+def _load_selected_settings_payload(
+    selected_settings_path: Path | None,
+    *,
+    strict: bool,
+    methods: list[str],
+) -> tuple[dict[str, dict[str, float]] | None, str | None]:
+    if selected_settings_path is None:
+        return None, "No selected-settings artifact was resolved; transfer summary skipped."
+    if not supports_primary_comparison(methods):
+        return None, "TF-IDF/BM25 pair not present; transfer summary skipped."
+    try:
+        payload = json.loads(selected_settings_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        if strict:
+            raise ClassHeldoutReportingValidationError(
+                f"Malformed selected settings JSON: {selected_settings_path}"
+            ) from exc
+        return None, "Selected-settings artifact was malformed; transfer summary skipped."
+
+    if not isinstance(payload, dict) or not isinstance(payload.get("selected_settings"), dict):
+        if strict:
+            raise ClassHeldoutReportingValidationError(
+                f"Selected settings JSON missing 'selected_settings' object: {selected_settings_path}"
+            )
+        return None, "Selected-settings artifact was invalid; transfer summary skipped."
+
+    selected_settings = payload["selected_settings"]
+    transfer_payload: dict[str, dict[str, float]] = {}
+    try:
+        for method in PRIMARY_COMPARISON_METHODS:
+            entry = selected_settings[method]
+            transfer_payload[method] = {
+                "development_selection_score": float(entry["heldout_score"]),
+                "development_mu": float(entry["mu"]),
+                "development_sigma": float(entry["sigma"]),
+            }
+    except (KeyError, TypeError, ValueError) as exc:
+        if strict:
+            raise ClassHeldoutReportingValidationError(
+                f"Selected settings JSON missing transfer summary fields: {selected_settings_path}"
+            ) from exc
+        return None, "Selected-settings artifact was incomplete; transfer summary skipped."
+    return transfer_payload, None
+
+
+def _build_transfer_summary(
+    transfer_payload: dict[str, dict[str, float]],
+    macro_summary: pd.DataFrame,
+    micro_summary: pd.DataFrame,
+) -> pd.DataFrame:
+    macro_by_method = macro_summary[macro_summary["method"].isin(PRIMARY_COMPARISON_METHODS)].set_index("method")
+    micro_by_method = micro_summary[micro_summary["method"].isin(PRIMARY_COMPARISON_METHODS)].set_index("method")
+    rows: list[dict[str, object]] = []
+    for method in PRIMARY_COMPARISON_METHODS:
+        development_mu = _coerce_float(transfer_payload[method]["development_mu"])
+        heldout_macro_mrr = _coerce_float(macro_by_method.loc[method, "mrr_mean"])
+        heldout_micro_mrr = _coerce_float(micro_by_method.loc[method, "mrr"])
+        rows.append(
+            {
+                "method": method,
+                "development_selection_score": _coerce_float(
+                    transfer_payload[method]["development_selection_score"]
+                ),
+                "development_mu": development_mu,
+                "development_sigma": _coerce_float(transfer_payload[method]["development_sigma"]),
+                "heldout_macro_mrr": heldout_macro_mrr,
+                "heldout_micro_mrr": heldout_micro_mrr,
+                "macro_transfer_gap": float(heldout_macro_mrr - development_mu),
+                "micro_transfer_gap": float(heldout_micro_mrr - development_mu),
+            }
+        )
+    return pd.DataFrame(rows).sort_values(["method"], kind="mergesort").reset_index(drop=True)
+
+
+def _write_interpretation_scaffold(
+    output_path: Path,
+    *,
+    source_csv: Path,
+    macro_summary: pd.DataFrame,
+    micro_summary: pd.DataFrame,
+    pairwise_overall: pd.DataFrame,
+    primary_recall_column: str,
+    transfer_summary: pd.DataFrame | None,
+    transfer_note: str | None,
+    methods: list[str],
+) -> None:
+    macro_rows = macro_summary[macro_summary["method"].isin(methods)].set_index("method")
+    micro_rows = micro_summary[micro_summary["method"].isin(methods)].set_index("method")
+    lines = [
+        "# Secondary Held-Out Class-Only Interpretation Scaffold",
+        "",
+        f"- Source CSV: `{source_csv}`",
+        f"- Methods compared: {', '.join(f'`{method}`' for method in methods)}",
+        "",
+        "## Macro Summary",
+        "",
+    ]
+    for method in methods:
+        lines.append(f"- `{method}` macro MRR: `{macro_rows.loc[method, 'mrr_mean']:.6f}`")
+    lines.extend(["", "## Micro Summary", ""])
+    for method in methods:
+        lines.append(f"- `{method}` micro MRR: `{micro_rows.loc[method, 'mrr']:.6f}`")
+    lines.extend(
+        [
+            "",
+            "## Trade-Off Prompts",
+            "",
+            f"- Compare `{primary_recall_column}` and `candidate_reduction_ratio` per method.",
+            "- Candidate Reduction Ratio remains descriptive and is not significance-tested.",
+            "",
+            "## Pairwise Inference (MRR)",
+            "",
+        ]
+    )
+    overall_mrr = pairwise_overall[pairwise_overall["metric"] == "mrr"].copy()
+    for row in overall_mrr.itertuples(index=False):
+        lines.append(
+            f"- `{row.aggregation_scope}` / `{row.method_a}` vs `{row.method_b}`: "
+            f"delta `{row.paired_delta:.6f}`, CI [`{row.ci_lower:.6f}`, `{row.ci_upper:.6f}`], "
+            f"p-value `{row.p_value:.6f}`"
+        )
+    lines.append("")
+    if transfer_summary is not None:
+        lines.extend(["## Transfer Summary", ""])
+        for row in transfer_summary.itertuples(index=False):
+            lines.append(
+                f"- `{row.method}` development score `{row.development_selection_score:.6f}`, "
+                f"held-out macro MRR `{row.heldout_macro_mrr:.6f}`, held-out micro MRR `{row.heldout_micro_mrr:.6f}`"
+            )
+        lines.append("")
+    elif transfer_note is not None:
+        lines.extend(["## Transfer Summary", "", f"- {transfer_note}", ""])
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def generate_class_heldout_reporting(
+    results_csv_path: str | Path | None,
+    output_dir: str | Path = "results/comparisons",
+    selected_settings_path: str | Path | None = None,
+) -> dict[str, Path]:
+    """Generate secondary held-out class-only reporting artifacts."""
+    source_csv = _resolve_results_csv(results_csv_path)
+    frame = pd.read_csv(source_csv)
+    validated, recall_columns, methods = _validate_results_frame(frame)
+    heldout_datasets = set(validated["dataset"].unique())
+
+    by_method_summary = _build_by_method_summary(validated, recall_columns, methods)
+    macro_summary = _build_macro_summary(by_method_summary, recall_columns, methods)
+    micro_summary = _build_micro_summary(validated, recall_columns, methods)
+    reduction_effectiveness = _build_reduction_effectiveness(validated, recall_columns, methods)
+    pairwise_overall = _build_pairwise_overall_inference(validated, recall_columns, methods)
+
+    selected_settings_json, selected_settings_explicit = _resolve_selected_settings_json(
+        selected_settings_path,
+        heldout_datasets=heldout_datasets,
+    )
+    transfer_payload, transfer_note = _load_selected_settings_payload(
+        selected_settings_json,
+        strict=selected_settings_explicit,
+        methods=methods,
+    )
+    transfer_summary = (
+        _build_transfer_summary(transfer_payload, macro_summary, micro_summary)
+        if transfer_payload is not None
+        else None
+    )
+
+    output_root = Path(output_dir) / source_csv.stem
+    output_root.mkdir(parents=True, exist_ok=True)
+    by_method_path = output_root / "class_heldout_by_method_summary.csv"
+    macro_path = output_root / "class_heldout_macro_summary.csv"
+    micro_path = output_root / "class_heldout_micro_summary.csv"
+    reduction_path = output_root / "class_heldout_reduction_effectiveness.csv"
+    pairwise_path = output_root / "class_heldout_pairwise_overall_inference.csv"
+    interpretation_path = output_root / "class_heldout_interpretation_scaffold.md"
+    transfer_path = output_root / "class_heldout_transfer_summary.csv"
+    manifest_path = output_root / "manifest.txt"
+
+    by_method_summary.to_csv(by_method_path, index=False)
+    macro_summary.to_csv(macro_path, index=False)
+    micro_summary.to_csv(micro_path, index=False)
+    reduction_effectiveness.to_csv(reduction_path, index=False, quoting=csv.QUOTE_MINIMAL)
+    pairwise_overall.to_csv(pairwise_path, index=False)
+    if transfer_summary is not None:
+        transfer_summary.to_csv(transfer_path, index=False)
+
+    _write_interpretation_scaffold(
+        interpretation_path,
+        source_csv=source_csv,
+        macro_summary=macro_summary,
+        micro_summary=micro_summary,
+        pairwise_overall=pairwise_overall,
+        primary_recall_column=recall_columns[-1],
+        transfer_summary=transfer_summary,
+        transfer_note=transfer_note,
+        methods=methods,
+    )
+    manifest_path.write_text(
+        "\n".join(
+            [
+                f"source_csv={source_csv}",
+                f"output_dir={output_root}",
+                f"selected_settings_json={selected_settings_json}" if selected_settings_json is not None else "selected_settings_json=",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    artifacts: dict[str, Path] = {
+        "source_csv": source_csv,
+        "output_dir": output_root,
+        "class_heldout_by_method_summary": by_method_path,
+        "class_heldout_macro_summary": macro_path,
+        "class_heldout_micro_summary": micro_path,
+        "class_heldout_reduction_effectiveness": reduction_path,
+        "class_heldout_pairwise_overall_inference": pairwise_path,
+        "class_heldout_interpretation_scaffold": interpretation_path,
+        "manifest": manifest_path,
+    }
+    if transfer_summary is not None:
+        artifacts["class_heldout_transfer_summary"] = transfer_path
+    return artifacts

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -34,6 +34,11 @@ class DatasetConfig:
 
 
 @dataclass(frozen=True)
+class SecondaryHeldoutDatasetConfig(DatasetConfig):
+    """Secondary held-out dataset configuration."""
+
+
+@dataclass(frozen=True)
 class TfidfGridEntry:
     """Validated TF-IDF hyperparameter entry."""
 
@@ -91,6 +96,7 @@ class RuntimeConfig:
 
     development_datasets: dict[str, DatasetConfig]
     heldout_datasets: dict[str, DatasetConfig]
+    heldout_secondary_datasets: dict[str, SecondaryHeldoutDatasetConfig]
     experiments: ExperimentConfig
     heldout: HeldoutConfig | None
 
@@ -204,6 +210,70 @@ def _validate_dataset_group(
         logger.info(
             "Validated %s '%s' (track=%s, version=%s)",
             field_name,
+            dataset_name,
+            loaded[dataset_name].track,
+            loaded[dataset_name].version,
+        )
+    return loaded
+
+
+def _validate_secondary_heldout_dataset_group(
+    raw_datasets: Any,
+    *,
+    path: Path,
+) -> dict[str, SecondaryHeldoutDatasetConfig]:
+    datasets = _ensure_mapping(raw_datasets, "heldout_secondary_datasets")
+    logger.info(
+        "Discovered %d dataset entry(ies) in %s.heldout_secondary_datasets",
+        len(datasets),
+        path,
+    )
+
+    loaded: dict[str, SecondaryHeldoutDatasetConfig] = {}
+    required_fields = (
+        "track",
+        "version",
+        "source_rdf",
+        "target_rdf",
+        "alignment_rdf",
+    )
+
+    for dataset_name, raw_config in datasets.items():
+        if not isinstance(raw_config, dict):
+            raise ValueError(
+                f"heldout_secondary_datasets '{dataset_name}' must be a mapping."
+            )
+        missing = [field for field in required_fields if field not in raw_config]
+        if missing:
+            raise ValueError(
+                "heldout_secondary_datasets "
+                f"'{dataset_name}' missing required fields: {', '.join(missing)}"
+            )
+
+        source_rdf = Path(raw_config["source_rdf"])
+        target_rdf = Path(raw_config["target_rdf"])
+        alignment_rdf = Path(raw_config["alignment_rdf"])
+        for label, rdf_path in (
+            ("source_rdf", source_rdf),
+            ("target_rdf", target_rdf),
+            ("alignment_rdf", alignment_rdf),
+        ):
+            if not rdf_path.exists():
+                raise FileNotFoundError(
+                    "heldout_secondary_datasets "
+                    f"'{dataset_name}' has missing file for '{label}': {rdf_path}"
+                )
+
+        loaded[dataset_name] = SecondaryHeldoutDatasetConfig(
+            name=dataset_name,
+            track=str(raw_config["track"]),
+            version=str(raw_config["version"]),
+            source_rdf=source_rdf,
+            target_rdf=target_rdf,
+            alignment_rdf=alignment_rdf,
+        )
+        logger.info(
+            "Validated heldout_secondary_datasets '%s' (track=%s, version=%s)",
             dataset_name,
             loaded[dataset_name].track,
             loaded[dataset_name].version,
@@ -396,6 +466,14 @@ def load_runtime_config(
         if "heldout_datasets" in content
         else {}
     )
+    heldout_secondary_datasets = (
+        _validate_secondary_heldout_dataset_group(
+            content["heldout_secondary_datasets"],
+            path=path,
+        )
+        if "heldout_secondary_datasets" in content
+        else {}
+    )
     experiments = _validate_experiment_config(content["experiments"])
     heldout = _validate_heldout_config(content["heldout"]) if "heldout" in content else None
     logger.info(
@@ -407,6 +485,7 @@ def load_runtime_config(
     return RuntimeConfig(
         development_datasets=development_datasets,
         heldout_datasets=heldout_datasets,
+        heldout_secondary_datasets=heldout_secondary_datasets,
         experiments=experiments,
         heldout=heldout,
     )

--- a/src/experiments/heldout_class_runner.py
+++ b/src/experiments/heldout_class_runner.py
@@ -1,0 +1,451 @@
+"""Secondary held-out class-alignment runner."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from datetime import datetime
+import json
+import logging
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import TypedDict, cast
+
+from pyoxigraph import NamedNode
+from tqdm import tqdm
+
+from src.config_loader import load_runtime_config
+from src.evaluation.metrics import compute_recall_at_ks_and_mrr
+from src.experiments.experiment_runner import _load_store_with_fallback
+from src.method_registry import (
+    fixed_method_hyperparameters,
+    fixed_method_names,
+    heldout_selected_method_names,
+    ordered_method_names,
+)
+from src.preprocessing.text_preprocessor import preprocess_text, validate_nltk_assets
+from src.rdf_utils.alignment_parser import load_alignment_mappings
+from src.rdf_utils.label_extractor import extract_entity_label
+from src.retrieval.bm25_retriever import Bm25Retriever
+from src.retrieval.char_ngram_retriever import CharNgramRetriever
+from src.retrieval.exact_match_retriever import ExactMatchRetriever
+from src.retrieval.tfidf_retriever import TfidfRetriever
+
+logger = logging.getLogger(__name__)
+
+RDF_TYPE = NamedNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+OWL_CLASS = NamedNode("http://www.w3.org/2002/07/owl#Class")
+
+FIXED_CSV_COLUMNS: tuple[str, ...] = (
+    "track",
+    "version",
+    "dataset",
+    "entity_type",
+    "method",
+    "hyperparameters",
+    "gold_count",
+    "target_pool_size",
+    "retained_candidate_size",
+    "candidate_reduction_ratio",
+    "mrr",
+    "runtime_seconds",
+)
+
+
+class HeldoutClassRunnerValidationError(ValueError):
+    """Raised when held-out class-only execution inputs are invalid."""
+
+
+class HeldoutClassResultRecord(TypedDict):
+    dataset_name: str
+    track: str
+    version: str
+    entity_type: str
+    model: str
+    hyperparameters: dict[str, object]
+    gold_count: int
+    target_pool_size: int
+    retained_candidate_size: int
+    candidate_reduction_ratio: float
+    recalls: dict[int, float]
+    mrr: float
+    runtime_seconds: float
+
+
+@dataclass(frozen=True)
+class HeldoutMethodRunSpec:
+    method_name: str
+    hyperparameters: dict[str, object]
+
+
+def _get_git_short_sha() -> str:
+    repo_root = Path(__file__).resolve().parents[2]
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=repo_root,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (subprocess.SubprocessError, OSError):
+        return "nogit"
+
+
+def _default_output_csv_path() -> Path:
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    git_sha = _get_git_short_sha()
+    return Path("results") / f"heldout_class_result_{timestamp}_{git_sha}.csv"
+
+
+def _resolve_selected_settings_json(
+    selected_settings_path: str | Path | None,
+) -> Path:
+    if selected_settings_path is not None:
+        path = Path(selected_settings_path).resolve()
+        if not path.exists():
+            raise FileNotFoundError(f"Selected settings JSON not found: {path}")
+        return path
+
+    candidates = sorted(
+        Path("results/comparisons").glob("**/heldout_selected_settings.json"),
+        key=lambda candidate: candidate.stat().st_mtime,
+    )
+    if not candidates:
+        raise FileNotFoundError(
+            "No results/comparisons/**/heldout_selected_settings.json files found."
+        )
+    return candidates[-1].resolve()
+
+
+def _load_selected_settings(selected_settings_path: Path) -> dict[str, dict[str, object]]:
+    try:
+        payload = json.loads(selected_settings_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise HeldoutClassRunnerValidationError(
+            f"Malformed selected settings JSON: {selected_settings_path}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise HeldoutClassRunnerValidationError(
+            f"Selected settings payload must be a JSON object: {selected_settings_path}"
+        )
+    selected_settings = payload.get("selected_settings")
+    if not isinstance(selected_settings, dict):
+        raise HeldoutClassRunnerValidationError(
+            "Selected settings JSON must contain a 'selected_settings' object."
+        )
+
+    required_hyperparameter_keys = {
+        "tfidf": ("ngram_range", "min_df", "max_df", "sublinear_tf"),
+        "bm25": ("k1", "b"),
+    }
+
+    resolved: dict[str, dict[str, object]] = {}
+    for method in heldout_selected_method_names():
+        entry = selected_settings.get(method)
+        if not isinstance(entry, dict):
+            raise HeldoutClassRunnerValidationError(
+                f"Selected settings JSON missing required method '{method}'."
+            )
+        hyperparameters = entry.get("hyperparameters")
+        if not isinstance(hyperparameters, dict):
+            raise HeldoutClassRunnerValidationError(
+                f"Selected settings for method '{method}' must include a hyperparameters object."
+            )
+        missing = [
+            key for key in required_hyperparameter_keys[method] if key not in hyperparameters
+        ]
+        if missing:
+            missing_str = ", ".join(missing)
+            raise HeldoutClassRunnerValidationError(
+                f"Selected settings for method '{method}' missing required hyperparameter keys: {missing_str}."
+            )
+        resolved[method] = hyperparameters
+    return resolved
+
+
+def _build_heldout_method_runs(
+    frozen_settings: dict[str, dict[str, object]],
+) -> list[HeldoutMethodRunSpec]:
+    method_runs: list[HeldoutMethodRunSpec] = []
+    runtime_methods = list(frozen_settings.keys()) + fixed_method_names(heldout=True)
+    for method_name in ordered_method_names(runtime_methods):
+        if method_name in frozen_settings:
+            hyperparameters = frozen_settings[method_name]
+        else:
+            hyperparameters = fixed_method_hyperparameters(method_name)
+        method_runs.append(
+            HeldoutMethodRunSpec(
+                method_name=method_name,
+                hyperparameters=hyperparameters,
+            )
+        )
+    return method_runs
+
+
+def _coerce_tfidf_ngram_range(value: object) -> tuple[int, int]:
+    if not isinstance(value, list) or len(value) != 2:
+        raise HeldoutClassRunnerValidationError(
+            "Selected settings for method 'tfidf' must include a two-item ngram_range list."
+        )
+    first, second = value
+    if not isinstance(first, int) or isinstance(first, bool):
+        raise HeldoutClassRunnerValidationError(
+            "Selected settings for method 'tfidf' must include an integer ngram_range[0]."
+        )
+    if not isinstance(second, int) or isinstance(second, bool):
+        raise HeldoutClassRunnerValidationError(
+            "Selected settings for method 'tfidf' must include an integer ngram_range[1]."
+        )
+    return (first, second)
+
+
+def _predict_for_method(
+    *,
+    method_name: str,
+    hyperparameters: dict[str, object],
+    target_entities: list[str],
+    target_labels: list[str],
+    target_labels_preprocessed: list[str],
+    target_tokens: list[list[str]],
+    source_label_map: dict[str, str],
+    source_label_preprocessed_map: dict[str, str],
+    source_token_map: dict[str, list[str]],
+    eval_sources: list[str],
+    k_max: int,
+) -> dict[str, list[tuple[str, float]]]:
+    if method_name == "tfidf":
+        retriever = TfidfRetriever(
+            ngram_range=_coerce_tfidf_ngram_range(hyperparameters["ngram_range"]),
+            min_df=cast(int | float, hyperparameters["min_df"]),
+            max_df=cast(int | float, hyperparameters["max_df"]),
+            sublinear_tf=cast(bool, hyperparameters["sublinear_tf"]),
+        )
+        retriever.fit_preprocessed(target_entities, target_labels_preprocessed)
+        return {
+            source_id: retriever.retrieve_preprocessed(
+                source_label_preprocessed_map[source_id],
+                k=k_max,
+            )
+            for source_id in eval_sources
+        }
+
+    if method_name == "bm25":
+        retriever = Bm25Retriever(
+            k1=float(cast(int | float, hyperparameters["k1"])),
+            b=float(cast(int | float, hyperparameters["b"])),
+        )
+        retriever.fit_tokenized(target_entities, target_tokens)
+        return {
+            source_id: retriever.retrieve_tokenized(
+                source_token_map[source_id],
+                k=k_max,
+            )
+            for source_id in eval_sources
+        }
+
+    if method_name == "exact_match":
+        retriever = ExactMatchRetriever()
+        retriever.fit(target_entities, target_labels)
+        return {
+            source_id: retriever.retrieve(
+                source_label_map[source_id],
+                k=k_max,
+            )
+            for source_id in eval_sources
+        }
+
+    if method_name == "char_ngram":
+        retriever = CharNgramRetriever()
+        retriever.fit(target_entities, target_labels)
+        return {
+            source_id: retriever.retrieve(
+                source_label_map[source_id],
+                k=k_max,
+            )
+            for source_id in eval_sources
+        }
+
+    raise HeldoutClassRunnerValidationError(
+        f"Unsupported registered held-out method '{method_name}'."
+    )
+
+
+def _build_labels(store, entity_ids: list[str]) -> list[str]:
+    return [extract_entity_label(store, uri) for uri in entity_ids]
+
+
+def _extract_owl_class_entities(store) -> list[str]:
+    entities: set[str] = set()
+    for quad in store.quads_for_pattern(None, RDF_TYPE, OWL_CLASS, None):
+        if isinstance(quad.subject, NamedNode):
+            entities.add(quad.subject.value)
+    return sorted(entities)
+
+
+def _preprocess_labels(labels: list[str]) -> tuple[list[list[str]], list[str]]:
+    tokenized = [preprocess_text(label) for label in labels]
+    joined = [" ".join(tokens) for tokens in tokenized]
+    return tokenized, joined
+
+
+def _build_csv_columns(evaluation_ks: list[int]) -> list[str]:
+    return [
+        *FIXED_CSV_COLUMNS[:10],
+        *(f"recall_at_{k}" for k in evaluation_ks),
+        *FIXED_CSV_COLUMNS[10:],
+    ]
+
+
+def _persist_results_to_csv(
+    results: list[HeldoutClassResultRecord],
+    output_csv_path: str | Path,
+    evaluation_ks: list[int],
+) -> None:
+    csv_columns = _build_csv_columns(evaluation_ks)
+    output_path = Path(output_csv_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with output_path.open("w", encoding="utf-8", newline="") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=csv_columns)
+        writer.writeheader()
+        for record in results:
+            row: dict[str, object] = {
+                "track": record["track"],
+                "version": record["version"],
+                "dataset": record["dataset_name"],
+                "entity_type": record["entity_type"],
+                "method": record["model"],
+                "hyperparameters": json.dumps(
+                    record["hyperparameters"], sort_keys=True, separators=(",", ":")
+                ),
+                "gold_count": record["gold_count"],
+                "target_pool_size": record["target_pool_size"],
+                "retained_candidate_size": record["retained_candidate_size"],
+                "candidate_reduction_ratio": record["candidate_reduction_ratio"],
+                "mrr": record["mrr"],
+                "runtime_seconds": record["runtime_seconds"],
+            }
+            for k in evaluation_ks:
+                row[f"recall_at_{k}"] = record["recalls"][k]
+            writer.writerow(row)
+
+
+def run_heldout_class_experiments(
+    config_path: str | Path = "config/runtime.yaml",
+    selected_settings_path: str | Path | None = None,
+    output_csv_path: str | Path | None = None,
+    show_progress: bool | None = None,
+) -> list[HeldoutClassResultRecord]:
+    """Run secondary held-out class-only evaluation."""
+    validate_nltk_assets()
+    progress_enabled = sys.stderr.isatty() if show_progress is None else show_progress
+    resolved_output_csv_path = (
+        Path(output_csv_path) if output_csv_path is not None else _default_output_csv_path()
+    )
+    runtime_config = load_runtime_config(config_path=config_path)
+    selected_settings_json = _resolve_selected_settings_json(selected_settings_path)
+    frozen_settings = _load_selected_settings(selected_settings_json)
+    method_runs = _build_heldout_method_runs(frozen_settings)
+    datasets = runtime_config.heldout_secondary_datasets
+    if not datasets:
+        raise HeldoutClassRunnerValidationError(
+            "Held-out class-only execution requires at least one heldout_secondary_datasets entry."
+        )
+
+    evaluation_ks = runtime_config.experiments.evaluation_ks
+    k_max = max(evaluation_ks)
+
+    results: list[HeldoutClassResultRecord] = []
+    dataset_names = list(datasets.keys())
+    dataset_iterator = tqdm(
+        dataset_names,
+        desc="HeldoutClassDatasets",
+        disable=not progress_enabled,
+    )
+    for dataset_name in dataset_iterator:
+        dataset = datasets[dataset_name]
+        source_store = _load_store_with_fallback(dataset.source_rdf)
+        target_store = _load_store_with_fallback(dataset.target_rdf)
+        gold_raw = load_alignment_mappings(dataset.alignment_rdf)
+        source_entities = _extract_owl_class_entities(source_store)
+        target_entities = _extract_owl_class_entities(target_store)
+        class_source_set = set(source_entities)
+        class_target_set = set(target_entities)
+        gold = {
+            source: target
+            for source, target in gold_raw.items()
+            if source in class_source_set and target in class_target_set
+        }
+        if not target_entities:
+            raise HeldoutClassRunnerValidationError(
+                f"Held-out secondary dataset '{dataset_name}' has zero class target entities."
+            )
+        if not gold:
+            raise HeldoutClassRunnerValidationError(
+                f"Held-out secondary dataset '{dataset_name}' has zero class gold mappings."
+            )
+
+        eval_sources = sorted(gold.keys())
+        target_labels = _build_labels(target_store, target_entities)
+        source_labels = _build_labels(source_store, eval_sources)
+        source_label_map = dict(zip(eval_sources, source_labels, strict=True))
+        target_tokens, target_labels_preprocessed = _preprocess_labels(target_labels)
+        source_tokens, source_labels_preprocessed = _preprocess_labels(source_labels)
+        source_label_preprocessed_map = dict(
+            zip(eval_sources, source_labels_preprocessed, strict=True)
+        )
+        source_token_map = dict(zip(eval_sources, source_tokens, strict=True))
+
+        target_pool_size = len(target_entities)
+        retained_candidate_size = min(k_max, target_pool_size)
+        candidate_reduction_ratio = 1.0 - (retained_candidate_size / target_pool_size)
+
+        for method_run in method_runs:
+            run_start = time.perf_counter()
+            predictions = _predict_for_method(
+                method_name=method_run.method_name,
+                hyperparameters=method_run.hyperparameters,
+                target_entities=target_entities,
+                target_labels=target_labels,
+                target_labels_preprocessed=target_labels_preprocessed,
+                target_tokens=target_tokens,
+                source_label_map=source_label_map,
+                source_label_preprocessed_map=source_label_preprocessed_map,
+                source_token_map=source_token_map,
+                eval_sources=eval_sources,
+                k_max=k_max,
+            )
+            raw_recalls, mrr = compute_recall_at_ks_and_mrr(predictions, gold, evaluation_ks)
+            recalls = {k: raw_recalls[k] for k in evaluation_ks}
+            results.append(
+                HeldoutClassResultRecord(
+                    dataset_name=dataset.name,
+                    track=dataset.track,
+                    version=dataset.version,
+                    entity_type="class",
+                    model=method_run.method_name,
+                    hyperparameters=method_run.hyperparameters,
+                    gold_count=len(gold),
+                    target_pool_size=target_pool_size,
+                    retained_candidate_size=retained_candidate_size,
+                    candidate_reduction_ratio=candidate_reduction_ratio,
+                    recalls=recalls,
+                    mrr=mrr,
+                    runtime_seconds=time.perf_counter() - run_start,
+                )
+            )
+
+    _persist_results_to_csv(
+        results,
+        output_csv_path=resolved_output_csv_path,
+        evaluation_ks=evaluation_ks,
+    )
+    logger.info(
+        "Persisted %d held-out class-only result record(s) to %s",
+        len(results),
+        resolved_output_csv_path,
+    )
+    return results

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ from src.logging_utils import setup_logging
 logger = logging.getLogger("src.main")
 
 if TYPE_CHECKING:
+    from src.experiments.heldout_class_runner import HeldoutClassResultRecord
     from src.experiments.heldout_kg_runner import HeldoutKgResultRecord
 
 
@@ -47,7 +48,6 @@ def generate_kg_heldout_reporting(
     results_csv_path: str | Path | None,
     output_dir: str | Path,
     selected_settings_path: str | Path | None,
-    query_level_csv_path: str | Path | None,
 ) -> dict[str, Path]:
     from src.analysis.kg_heldout_reporting import generate_kg_heldout_reporting as _impl
 
@@ -55,7 +55,23 @@ def generate_kg_heldout_reporting(
         results_csv_path=results_csv_path,
         output_dir=output_dir,
         selected_settings_path=selected_settings_path,
-        query_level_csv_path=query_level_csv_path,
+    )
+
+
+def generate_class_heldout_reporting(
+    *,
+    results_csv_path: str | Path | None,
+    output_dir: str | Path,
+    selected_settings_path: str | Path | None,
+) -> dict[str, Path]:
+    from src.analysis.class_heldout_reporting import (
+        generate_class_heldout_reporting as _impl,
+    )
+
+    return _impl(
+        results_csv_path=results_csv_path,
+        output_dir=output_dir,
+        selected_settings_path=selected_settings_path,
     )
 
 
@@ -96,6 +112,25 @@ def run_heldout_kg_experiments(
 ) -> list[HeldoutKgResultRecord]:
     from src.experiments.heldout_kg_runner import (
         run_heldout_kg_experiments as _impl,
+    )
+
+    return _impl(
+        config_path=config_path,
+        selected_settings_path=selected_settings_path,
+        output_csv_path=output_csv_path,
+        show_progress=show_progress,
+    )
+
+
+def run_heldout_class_experiments(
+    *,
+    config_path: str | Path,
+    selected_settings_path: str | Path | None,
+    output_csv_path: str | Path | None,
+    show_progress: bool | None,
+) -> list[HeldoutClassResultRecord]:
+    from src.experiments.heldout_class_runner import (
+        run_heldout_class_experiments as _impl,
     )
 
     return _impl(
@@ -246,17 +281,33 @@ def _build_report_heldout_kg_parser(parser: argparse.ArgumentParser) -> None:
         ),
     )
     parser.add_argument(
-        "--query-level-csv",
+        "--output-dir",
+        default="results/comparisons",
+        help="Directory where held-out reporting artifacts are written (default: results/comparisons).",
+    )
+
+
+def _build_report_heldout_class_parser(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--results-csv",
         default=None,
         help=(
-            "Path to held-out query-level CSV. If omitted, a paired heldout_query_result_* file "
-            "is auto-detected from the held-out results CSV."
+            "Path to held-out class-only results CSV. If omitted, the latest "
+            "results/heldout_class_result_*.csv is used."
+        ),
+    )
+    parser.add_argument(
+        "--selected-settings-json",
+        default=None,
+        help=(
+            "Path to heldout_selected_settings.json. If omitted, the latest "
+            "results/comparisons/**/heldout_selected_settings.json is used when available."
         ),
     )
     parser.add_argument(
         "--output-dir",
         default="results/comparisons",
-        help="Directory where held-out reporting artifacts are written (default: results/comparisons).",
+        help="Directory where held-out class-only reporting artifacts are written (default: results/comparisons).",
     )
 
 
@@ -280,6 +331,41 @@ def _build_run_heldout_kg_parser(parser: argparse.ArgumentParser) -> None:
         help=(
             "Output CSV path. If omitted, a heldout run-stamped file is created in results/ "
             "(heldout_result_YYYYMMDD_HHMMSS_<gitsha>.csv)."
+        ),
+    )
+    progress_group = parser.add_mutually_exclusive_group()
+    progress_group.add_argument(
+        "--progress",
+        action="store_true",
+        help="Force-enable progress bars.",
+    )
+    progress_group.add_argument(
+        "--no-progress",
+        action="store_true",
+        help="Force-disable progress bars.",
+    )
+
+
+def _build_run_heldout_class_parser(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--config-path",
+        default="config/runtime.yaml",
+        help="Path to runtime YAML config (default: config/runtime.yaml).",
+    )
+    parser.add_argument(
+        "--selected-settings-json",
+        default=None,
+        help=(
+            "Path to heldout_selected_settings.json. If omitted, the latest "
+            "results/comparisons/**/heldout_selected_settings.json is used."
+        ),
+    )
+    parser.add_argument(
+        "--output-csv-path",
+        default=None,
+        help=(
+            "Output CSV path. If omitted, a heldout class-only run-stamped file is created in results/ "
+            "(heldout_class_result_YYYYMMDD_HHMMSS_<gitsha>.csv)."
         ),
     )
     progress_group = parser.add_mutually_exclusive_group()
@@ -349,6 +435,60 @@ def _build_heldout_full_run_parser(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _build_heldout_class_full_run_parser(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--config-path",
+        default="config/runtime.yaml",
+        help="Path to runtime YAML config (default: config/runtime.yaml).",
+    )
+    parser.add_argument(
+        "--dev-results-csv",
+        default=None,
+        help=(
+            "Path to development results CSV used for held-out selection. If omitted, the latest "
+            "results/result_*.csv is used when selection runs."
+        ),
+    )
+    parser.add_argument(
+        "--selected-settings-json",
+        default=None,
+        help=(
+            "Optional heldout_selected_settings.json override. If provided, the selection stage is skipped."
+        ),
+    )
+    parser.add_argument(
+        "--heldout-results-csv",
+        default=None,
+        help=(
+            "Optional held-out class-only results CSV override. If provided, the held-out class-only run stage is skipped."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="results/comparisons",
+        help="Directory where held-out class-only report artifacts are written (default: results/comparisons).",
+    )
+    parser.add_argument(
+        "--output-csv-path",
+        default=None,
+        help=(
+            "Explicit output CSV path for the held-out class-only run stage. Ignored when --heldout-results-csv "
+            "is provided."
+        ),
+    )
+    progress_group = parser.add_mutually_exclusive_group()
+    progress_group.add_argument(
+        "--progress",
+        action="store_true",
+        help="Force-enable progress bars for the held-out class-only run stage.",
+    )
+    progress_group.add_argument(
+        "--no-progress",
+        action="store_true",
+        help="Force-disable progress bars for the held-out class-only run stage.",
+    )
+
+
 def _build_full_run_parser(parser: argparse.ArgumentParser) -> None:
     _build_run_parser(parser)
     parser.add_argument(
@@ -403,17 +543,35 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     _build_report_heldout_kg_parser(report_heldout_kg_parser)
 
+    report_heldout_class_parser = subparsers.add_parser(
+        "report-heldout-class",
+        help="Generate held-out class-only reporting artifacts (secondary benchmark).",
+    )
+    _build_report_heldout_class_parser(report_heldout_class_parser)
+
     heldout_run_parser = subparsers.add_parser(
         "run-heldout-kg",
         help="Run frozen held-out KG evaluation by entity type.",
     )
     _build_run_heldout_kg_parser(heldout_run_parser)
 
+    heldout_class_run_parser = subparsers.add_parser(
+        "run-heldout-class",
+        help="Run frozen held-out class-only evaluation.",
+    )
+    _build_run_heldout_class_parser(heldout_class_run_parser)
+
     heldout_full_run_parser = subparsers.add_parser(
         "heldout-full-run",
         help="Run the full held-out KG workflow: selection, held-out execution, and reporting.",
     )
     _build_heldout_full_run_parser(heldout_full_run_parser)
+
+    heldout_class_full_run_parser = subparsers.add_parser(
+        "heldout-class-full-run",
+        help="Run the full secondary class-only held-out workflow: selection, execution, and reporting.",
+    )
+    _build_heldout_class_full_run_parser(heldout_class_full_run_parser)
 
     full_run_parser = subparsers.add_parser(
         "full-run",
@@ -466,15 +624,28 @@ def _resolve_new_heldout_result_file(
     return new_files[-1]
 
 
-def _infer_query_csv_from_results_csv(results_csv_path: str | Path) -> Path:
-    path = Path(results_csv_path).resolve()
-    stem = path.stem
-    if stem.startswith("heldout_result_"):
-        suffix = stem.removeprefix("heldout_result_")
-        name = f"heldout_query_result_{suffix}.csv"
-    else:
-        name = f"{stem}_query.csv"
-    return path.with_name(name)
+def _collect_existing_heldout_class_result_files(
+    results_dir: Path = Path("results"),
+) -> set[Path]:
+    if not results_dir.exists():
+        return set()
+    return {
+        path.resolve() for path in results_dir.glob("heldout_class_result_*.csv")
+    }
+
+
+def _resolve_new_heldout_class_result_file(
+    existing_files: set[Path], results_dir: Path = Path("results")
+) -> Path:
+    current_files = {
+        path.resolve() for path in results_dir.glob("heldout_class_result_*.csv")
+    }
+    new_files = sorted(current_files - existing_files, key=lambda p: p.stat().st_mtime)
+    if not new_files:
+        raise FileNotFoundError(
+            "No new heldout_class_result_*.csv file was created in 'results/' for this run."
+        )
+    return new_files[-1]
 
 
 def _run_experiment_cli(args: argparse.Namespace) -> int:
@@ -570,9 +741,18 @@ def _run_report_heldout_kg_cli(args: argparse.Namespace) -> int:
         results_csv_path=args.results_csv,
         output_dir=args.output_dir,
         selected_settings_path=args.selected_settings_json,
-        query_level_csv_path=args.query_level_csv,
     )
     print(f"Held-Out KG Report Dir: {artifacts['output_dir']}")
+    return 0
+
+
+def _run_report_heldout_class_cli(args: argparse.Namespace) -> int:
+    artifacts = generate_class_heldout_reporting(
+        results_csv_path=args.results_csv,
+        output_dir=args.output_dir,
+        selected_settings_path=args.selected_settings_json,
+    )
+    print(f"Held-Out Class-Only Report Dir: {artifacts['output_dir']}")
     return 0
 
 
@@ -598,13 +778,33 @@ def _run_heldout_kg_cli(args: argparse.Namespace) -> int:
         raise FileNotFoundError(
             f"Expected held-out output CSV was not created: {final_output_path}"
         )
-    query_output_path = _infer_query_csv_from_results_csv(final_output_path)
-    if not query_output_path.exists():
-        raise FileNotFoundError(
-            f"Expected held-out query-level CSV was not created: {query_output_path}"
-        )
     print(f"Held-Out KG Results CSV: {final_output_path}")
-    print(f"Held-Out KG Query CSV: {query_output_path}")
+    return 0
+
+
+def _run_heldout_class_cli(args: argparse.Namespace) -> int:
+    show_progress = _resolve_show_progress(args)
+    existing_files = (
+        _collect_existing_heldout_class_result_files()
+        if args.output_csv_path is None
+        else set()
+    )
+    run_heldout_class_experiments(
+        config_path=args.config_path,
+        selected_settings_path=args.selected_settings_json,
+        output_csv_path=args.output_csv_path,
+        show_progress=show_progress,
+    )
+    final_output_path = (
+        Path(args.output_csv_path)
+        if args.output_csv_path
+        else _resolve_new_heldout_class_result_file(existing_files)
+    )
+    if not final_output_path.exists():
+        raise FileNotFoundError(
+            f"Expected held-out class-only output CSV was not created: {final_output_path}"
+        )
+    print(f"Held-Out Class-Only Results CSV: {final_output_path}")
     return 0
 
 
@@ -647,6 +847,25 @@ def _resolve_heldout_manifest_dir(
     return Path(output_dir).resolve() / "heldout_full_run_partial"
 
 
+def _resolve_heldout_class_manifest_dir(
+    *,
+    output_dir: str | Path,
+    report_output_dir: Path | None,
+    heldout_results_csv: Path | None,
+    heldout_results_csv_arg: str | Path | None,
+    output_csv_path_arg: str | Path | None,
+) -> Path:
+    if report_output_dir is not None:
+        return report_output_dir.resolve()
+    if heldout_results_csv is not None:
+        return Path(output_dir).resolve() / heldout_results_csv.stem
+    if heldout_results_csv_arg is not None:
+        return Path(output_dir).resolve() / Path(heldout_results_csv_arg).stem
+    if output_csv_path_arg is not None:
+        return Path(output_dir).resolve() / Path(output_csv_path_arg).stem
+    return Path(output_dir).resolve() / "heldout_class_full_run_partial"
+
+
 def _run_heldout_full_run_cli(args: argparse.Namespace) -> int:
     started_at = datetime.now()
     start_perf = time.perf_counter()
@@ -659,7 +878,6 @@ def _run_heldout_full_run_cli(args: argparse.Namespace) -> int:
 
     selected_settings_path: Path
     heldout_results_csv: Path
-    query_level_csv: Path
     development_results_csv: Path | None = None
     report_output_dir: Path | None = None
     caught_exc: Exception | None = None
@@ -695,11 +913,6 @@ def _run_heldout_full_run_cli(args: argparse.Namespace) -> int:
                 args.heldout_results_csv,
                 label="Held-out results CSV",
             )
-            query_level_csv = _infer_query_csv_from_results_csv(heldout_results_csv)
-            if not query_level_csv.exists():
-                raise FileNotFoundError(
-                    f"Held-out query-level CSV not found for provided held-out results CSV: {query_level_csv}"
-                )
             stage_status["run_heldout_kg"] = "skipped"
         else:
             logger.info(
@@ -730,11 +943,6 @@ def _run_heldout_full_run_cli(args: argparse.Namespace) -> int:
                 raise FileNotFoundError(
                     f"Expected held-out output CSV was not created: {heldout_results_csv}"
                 )
-            query_level_csv = _infer_query_csv_from_results_csv(heldout_results_csv)
-            if not query_level_csv.exists():
-                raise FileNotFoundError(
-                    f"Expected held-out query-level CSV was not created: {query_level_csv}"
-                )
             stage_status["run_heldout_kg"] = "success"
             logger.info("Completed heldout-full-run stage=%s", "run_heldout_kg")
 
@@ -749,7 +957,6 @@ def _run_heldout_full_run_cli(args: argparse.Namespace) -> int:
             results_csv_path=heldout_results_csv,
             output_dir=args.output_dir,
             selected_settings_path=selected_settings_path,
-            query_level_csv_path=query_level_csv,
         )
         report_output_dir = Path(report_artifacts["output_dir"]).resolve()
         stage_status["report_heldout_kg"] = "success"
@@ -799,7 +1006,6 @@ def _run_heldout_full_run_cli(args: argparse.Namespace) -> int:
                 f"development_results_csv={development_results_csv if development_results_csv is not None else ''}",
                 f"selected_settings_json={selected_settings_path.resolve() if 'selected_settings_path' in locals() else ''}",
                 f"heldout_results_csv={heldout_results_csv.resolve() if 'heldout_results_csv' in locals() else ''}",
-                f"query_level_csv={query_level_csv.resolve() if 'query_level_csv' in locals() else ''}",
                 f"report_output_dir={report_output_dir if report_output_dir is not None else ''}",
                 f"stage_select_heldout_settings={stage_status['select_heldout_settings']}",
                 f"stage_run_heldout_kg={stage_status['run_heldout_kg']}",
@@ -815,9 +1021,146 @@ def _run_heldout_full_run_cli(args: argparse.Namespace) -> int:
 
     print(f"Selected Settings JSON: {selected_settings_path}")
     print(f"Held-Out KG Results CSV: {heldout_results_csv}")
-    print(f"Held-Out KG Query CSV: {query_level_csv}")
     print(f"Held-Out KG Report Dir: {report_output_dir}")
     print(f"Held-Out Full Run Manifest: {manifest_path}")
+    return 0
+
+
+def _run_heldout_class_full_run_cli(args: argparse.Namespace) -> int:
+    started_at = datetime.now()
+    start_perf = time.perf_counter()
+    show_progress = _resolve_show_progress(args)
+    stage_status: dict[str, str] = {
+        "select_heldout_settings": "not_run",
+        "run_heldout_class": "not_run",
+        "report_heldout_class": "not_run",
+    }
+
+    selected_settings_path: Path
+    heldout_results_csv: Path
+    development_results_csv: Path | None = None
+    report_output_dir: Path | None = None
+    caught_exc: Exception | None = None
+
+    try:
+        if args.selected_settings_json:
+            selected_settings_path = _resolve_existing_file(
+                args.selected_settings_json,
+                label="Selected settings JSON",
+            )
+            development_results_csv = _load_selected_settings_source_csv(selected_settings_path)
+            stage_status["select_heldout_settings"] = "skipped"
+        else:
+            selection_artifacts = generate_heldout_selection(
+                results_csv_path=args.dev_results_csv,
+                config_path=args.config_path,
+                output_dir=args.output_dir,
+            )
+            selected_settings_path = Path(selection_artifacts["heldout_selected_settings"]).resolve()
+            development_results_csv = Path(selection_artifacts["source_csv"]).resolve()
+            stage_status["select_heldout_settings"] = "success"
+
+        if args.heldout_results_csv:
+            heldout_results_csv = _resolve_existing_file(
+                args.heldout_results_csv,
+                label="Held-out class-only results CSV",
+            )
+            stage_status["run_heldout_class"] = "skipped"
+        else:
+            existing_files = (
+                _collect_existing_heldout_class_result_files()
+                if args.output_csv_path is None
+                else set()
+            )
+            run_heldout_class_experiments(
+                config_path=args.config_path,
+                selected_settings_path=selected_settings_path,
+                output_csv_path=args.output_csv_path,
+                show_progress=show_progress,
+            )
+            heldout_results_csv = (
+                Path(args.output_csv_path).resolve()
+                if args.output_csv_path
+                else _resolve_new_heldout_class_result_file(existing_files)
+            )
+            if not heldout_results_csv.exists():
+                raise FileNotFoundError(
+                    f"Expected held-out class-only output CSV was not created: {heldout_results_csv}"
+                )
+            stage_status["run_heldout_class"] = "success"
+
+        report_artifacts = generate_class_heldout_reporting(
+            results_csv_path=heldout_results_csv,
+            output_dir=args.output_dir,
+            selected_settings_path=selected_settings_path,
+        )
+        report_output_dir = Path(report_artifacts["output_dir"]).resolve()
+        stage_status["report_heldout_class"] = "success"
+    except Exception as exc:
+        caught_exc = exc
+        failed_stage = next(
+            (
+                stage
+                for stage in (
+                    "select_heldout_settings",
+                    "run_heldout_class",
+                    "report_heldout_class",
+                )
+                if stage_status[stage] == "not_run"
+            ),
+            "unknown",
+        )
+        if failed_stage != "unknown":
+            stage_status[failed_stage] = "failed"
+        logger.exception(
+            "Heldout-class-full-run stage failed stage=%s dev_results_csv=%s config_path=%s selected_settings_json=%s heldout_results_csv=%s output_dir=%s error=%s: %s",
+            failed_stage,
+            args.dev_results_csv,
+            args.config_path,
+            args.selected_settings_json,
+            args.heldout_results_csv,
+            args.output_dir,
+            type(exc).__name__,
+            exc,
+        )
+    ended_at = datetime.now()
+    elapsed_seconds = time.perf_counter() - start_perf
+    manifest_dir = _resolve_heldout_class_manifest_dir(
+        output_dir=args.output_dir,
+        report_output_dir=report_output_dir,
+        heldout_results_csv=heldout_results_csv if "heldout_results_csv" in locals() else None,
+        heldout_results_csv_arg=args.heldout_results_csv,
+        output_csv_path_arg=args.output_csv_path,
+    )
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = manifest_dir / "heldout_class_full_run_manifest.txt"
+    manifest_path.write_text(
+        "\n".join(
+            [
+                f"generated_at_start={started_at.isoformat(timespec='seconds')}",
+                f"generated_at_end={ended_at.isoformat(timespec='seconds')}",
+                f"elapsed_seconds={elapsed_seconds:.6f}",
+                f"git_sha={_get_git_short_sha()}",
+                f"config_path={Path(args.config_path).resolve()}",
+                f"development_results_csv={development_results_csv if development_results_csv is not None else ''}",
+                f"selected_settings_json={selected_settings_path.resolve() if 'selected_settings_path' in locals() else ''}",
+                f"heldout_results_csv={heldout_results_csv.resolve() if 'heldout_results_csv' in locals() else ''}",
+                f"report_output_dir={report_output_dir if report_output_dir is not None else ''}",
+                f"stage_select_heldout_settings={stage_status['select_heldout_settings']}",
+                f"stage_run_heldout_class={stage_status['run_heldout_class']}",
+                f"stage_report_heldout_class={stage_status['report_heldout_class']}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    if caught_exc is not None:
+        raise caught_exc
+
+    print(f"Selected Settings JSON: {selected_settings_path}")
+    print(f"Held-Out Class-Only Results CSV: {heldout_results_csv}")
+    print(f"Held-Out Class-Only Report Dir: {report_output_dir}")
+    print(f"Held-Out Class-Only Full Run Manifest: {manifest_path}")
     return 0
 
 
@@ -985,10 +1328,16 @@ def main(argv: list[str] | None = None) -> int:
             return _run_depth_analysis_cli(args)
         if args.command == "report-heldout-kg":
             return _run_report_heldout_kg_cli(args)
+        if args.command == "report-heldout-class":
+            return _run_report_heldout_class_cli(args)
         if args.command == "run-heldout-kg":
             return _run_heldout_kg_cli(args)
+        if args.command == "run-heldout-class":
+            return _run_heldout_class_cli(args)
         if args.command == "heldout-full-run":
             return _run_heldout_full_run_cli(args)
+        if args.command == "heldout-class-full-run":
+            return _run_heldout_class_full_run_cli(args)
         if args.command == "full-run":
             return _run_full_run_cli(args)
         return _run_experiment_cli(args)

--- a/tests/test_class_heldout_reporting.py
+++ b/tests/test_class_heldout_reporting.py
@@ -1,0 +1,202 @@
+import csv
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.analysis.class_heldout_reporting import (
+    ClassHeldoutReportingValidationError,
+    generate_class_heldout_reporting,
+)
+
+
+class ClassHeldoutReportingTests(unittest.TestCase):
+    def _write_results_csv(self, path: Path) -> None:
+        rows = [
+            {
+                "track": "bioml-supervised",
+                "version": "2022",
+                "dataset": "bio1",
+                "entity_type": "class",
+                "method": "tfidf",
+                "hyperparameters": '{"cfg":"tfidf"}',
+                "gold_count": 10,
+                "target_pool_size": 100,
+                "retained_candidate_size": 50,
+                "candidate_reduction_ratio": 0.50,
+                "recall_at_50": 0.90,
+                "mrr": 0.80,
+                "runtime_seconds": 0.1,
+            },
+            {
+                "track": "bioml-supervised",
+                "version": "2022",
+                "dataset": "bio1",
+                "entity_type": "class",
+                "method": "bm25",
+                "hyperparameters": '{"cfg":"bm25"}',
+                "gold_count": 10,
+                "target_pool_size": 100,
+                "retained_candidate_size": 50,
+                "candidate_reduction_ratio": 0.50,
+                "recall_at_50": 0.85,
+                "mrr": 0.75,
+                "runtime_seconds": 0.1,
+            },
+            {
+                "track": "bioml-supervised",
+                "version": "2022",
+                "dataset": "bio1",
+                "entity_type": "class",
+                "method": "exact_match",
+                "hyperparameters": '{"normalization":"light_v1"}',
+                "gold_count": 10,
+                "target_pool_size": 100,
+                "retained_candidate_size": 50,
+                "candidate_reduction_ratio": 0.50,
+                "recall_at_50": 0.60,
+                "mrr": 0.55,
+                "runtime_seconds": 0.1,
+            },
+            {
+                "track": "bioml-supervised",
+                "version": "2022",
+                "dataset": "bio1",
+                "entity_type": "class",
+                "method": "char_ngram",
+                "hyperparameters": '{"normalization":"light_v1","analyzer":"char_wb","ngram_range":[3,5]}',
+                "gold_count": 10,
+                "target_pool_size": 100,
+                "retained_candidate_size": 50,
+                "candidate_reduction_ratio": 0.50,
+                "recall_at_50": 0.70,
+                "mrr": 0.65,
+                "runtime_seconds": 0.1,
+            },
+            {
+                "track": "bioml-unsupervised",
+                "version": "2022",
+                "dataset": "bio2",
+                "entity_type": "class",
+                "method": "tfidf",
+                "hyperparameters": '{"cfg":"tfidf"}',
+                "gold_count": 20,
+                "target_pool_size": 80,
+                "retained_candidate_size": 50,
+                "candidate_reduction_ratio": 0.375,
+                "recall_at_50": 0.88,
+                "mrr": 0.78,
+                "runtime_seconds": 0.1,
+            },
+            {
+                "track": "bioml-unsupervised",
+                "version": "2022",
+                "dataset": "bio2",
+                "entity_type": "class",
+                "method": "bm25",
+                "hyperparameters": '{"cfg":"bm25"}',
+                "gold_count": 20,
+                "target_pool_size": 80,
+                "retained_candidate_size": 50,
+                "candidate_reduction_ratio": 0.375,
+                "recall_at_50": 0.84,
+                "mrr": 0.73,
+                "runtime_seconds": 0.1,
+            },
+            {
+                "track": "bioml-unsupervised",
+                "version": "2022",
+                "dataset": "bio2",
+                "entity_type": "class",
+                "method": "exact_match",
+                "hyperparameters": '{"normalization":"light_v1"}',
+                "gold_count": 20,
+                "target_pool_size": 80,
+                "retained_candidate_size": 50,
+                "candidate_reduction_ratio": 0.375,
+                "recall_at_50": 0.50,
+                "mrr": 0.45,
+                "runtime_seconds": 0.1,
+            },
+            {
+                "track": "bioml-unsupervised",
+                "version": "2022",
+                "dataset": "bio2",
+                "entity_type": "class",
+                "method": "char_ngram",
+                "hyperparameters": '{"normalization":"light_v1","analyzer":"char_wb","ngram_range":[3,5]}',
+                "gold_count": 20,
+                "target_pool_size": 80,
+                "retained_candidate_size": 50,
+                "candidate_reduction_ratio": 0.375,
+                "recall_at_50": 0.65,
+                "mrr": 0.60,
+                "runtime_seconds": 0.1,
+            },
+        ]
+        with path.open("w", encoding="utf-8", newline="") as csv_file:
+            writer = csv.DictWriter(csv_file, fieldnames=list(rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(rows)
+
+    def _write_selected_settings(self, path: Path) -> None:
+        payload = {
+            "heldout_datasets": ["bio1", "bio2"],
+            "selected_settings": {
+                "tfidf": {"heldout_score": 0.8, "mu": 0.78, "sigma": 0.04},
+                "bm25": {"heldout_score": 0.74, "mu": 0.73, "sigma": 0.03},
+            },
+        }
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+
+    def test_generates_separate_class_only_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            results_csv = tmp / "heldout_class_result_fixture.csv"
+            selected_json = tmp / "heldout_selected_settings.json"
+            self._write_results_csv(results_csv)
+            self._write_selected_settings(selected_json)
+
+            artifacts = generate_class_heldout_reporting(
+                results_csv_path=results_csv,
+                output_dir=tmp / "comparisons",
+                selected_settings_path=selected_json,
+            )
+
+            expected = {
+                "source_csv",
+                "output_dir",
+                "class_heldout_by_method_summary",
+                "class_heldout_macro_summary",
+                "class_heldout_micro_summary",
+                "class_heldout_reduction_effectiveness",
+                "class_heldout_pairwise_overall_inference",
+                "class_heldout_interpretation_scaffold",
+                "class_heldout_transfer_summary",
+                "manifest",
+            }
+            self.assertEqual(set(artifacts.keys()), expected)
+
+            with Path(artifacts["class_heldout_by_method_summary"]).open(
+                encoding="utf-8"
+            ) as csv_file:
+                rows = list(csv.DictReader(csv_file))
+            self.assertEqual({row["method"] for row in rows}, {"tfidf", "bm25", "exact_match", "char_ngram"})
+
+    def test_fails_when_non_class_rows_are_present(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            results_csv = tmp / "heldout_class_result_fixture.csv"
+            self._write_results_csv(results_csv)
+            text = results_csv.read_text(encoding="utf-8").replace(",class,", ",instance,", 1)
+            results_csv.write_text(text, encoding="utf-8")
+            with self.assertRaises(ClassHeldoutReportingValidationError):
+                generate_class_heldout_reporting(
+                    results_csv_path=results_csv,
+                    output_dir=tmp / "comparisons",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from src.config_loader import (
     DatasetConfig,
     ExperimentConfig,
+    SecondaryHeldoutDatasetConfig,
     get_dataset_config,
     load_runtime_config,
 )
@@ -293,6 +294,37 @@ heldout:
             runtime = load_runtime_config(config_path)
 
         self.assertEqual(runtime.experiments.bm25_grid[0].k1, 0.0)
+
+    def test_secondary_heldout_class_only_loads(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = self._write_valid_config(tmp)
+            source = tmp / "source.rdf"
+            target = tmp / "target.rdf"
+            alignment = tmp / "alignment.rdf"
+            config_path.write_text(
+                config_path.read_text(encoding="utf-8")
+                + "\n".join(
+                    [
+                        "heldout_secondary_datasets:",
+                        "  class_fixture:",
+                        "    track: bioml-supervised",
+                        '    version: "2022"',
+                        f"    source_rdf: {source}",
+                        f"    target_rdf: {target}",
+                        f"    alignment_rdf: {alignment}",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            runtime = load_runtime_config(config_path)
+
+        self.assertIn("class_fixture", runtime.heldout_secondary_datasets)
+        self.assertIsInstance(
+            runtime.heldout_secondary_datasets["class_fixture"],
+            SecondaryHeldoutDatasetConfig,
+        )
+
 
 
 if __name__ == "__main__":

--- a/tests/test_heldout_class_runner.py
+++ b/tests/test_heldout_class_runner.py
@@ -1,0 +1,204 @@
+import csv
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.experiments.heldout_class_runner import (
+    HeldoutClassRunnerValidationError,
+    run_heldout_class_experiments,
+)
+
+
+def _source_rdf() -> str:
+    return """<?xml version="1.0"?>
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+  xmlns:owl="http://www.w3.org/2002/07/owl#">
+  <owl:Class rdf:about="http://example.org/source#Disease">
+    <rdfs:label>DiseaseEntity</rdfs:label>
+  </owl:Class>
+</rdf:RDF>
+"""
+
+
+def _target_rdf() -> str:
+    return """<?xml version="1.0"?>
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+  xmlns:owl="http://www.w3.org/2002/07/owl#">
+  <owl:Class rdf:about="http://example.org/target#Disease">
+    <rdfs:label>disease entity</rdfs:label>
+  </owl:Class>
+</rdf:RDF>
+"""
+
+
+def _alignment_rdf() -> str:
+    return """<?xml version="1.0"?>
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns="http://knowledgeweb.semanticweb.org/heterogeneity/alignment#">
+  <Alignment>
+    <map>
+      <Cell>
+        <entity1 rdf:resource="http://example.org/source#Disease"/>
+        <entity2 rdf:resource="http://example.org/target#Disease"/>
+        <relation>=</relation>
+        <measure>1.0</measure>
+      </Cell>
+    </map>
+  </Alignment>
+</rdf:RDF>
+"""
+
+
+class HeldoutClassRunnerTests(unittest.TestCase):
+    def _write_config(
+        self,
+        tmp: Path,
+        *,
+        target_rdf_text: str | None = None,
+    ) -> Path:
+        source = tmp / "source.rdf"
+        target = tmp / "target.rdf"
+        alignment = tmp / "alignment.rdf"
+        source.write_text(_source_rdf(), encoding="utf-8")
+        target.write_text(target_rdf_text or _target_rdf(), encoding="utf-8")
+        alignment.write_text(_alignment_rdf(), encoding="utf-8")
+
+        config_path = tmp / "runtime.yaml"
+        config_path.write_text(
+            "\n".join(
+                [
+                    "experiments:",
+                    "  evaluation_ks: [1, 5]",
+                    "  tfidf_grid:",
+                    "    - ngram_range: [1, 1]",
+                    "      min_df: 1",
+                    "      max_df: 1.0",
+                    "      sublinear_tf: false",
+                    "  bm25_grid:",
+                    "    - k1: 1.5",
+                    "      b: 0.75",
+                    "development_datasets:",
+                    "  dev_fixture:",
+                    "    track: conf",
+                    '    version: "v1"',
+                    f"    source_rdf: {source}",
+                    f"    target_rdf: {target}",
+                    f"    alignment_rdf: {alignment}",
+                    "heldout_datasets:",
+                    "  kg_fixture:",
+                    "    track: kg",
+                    '    version: "heldout-v1"',
+                    f"    source_rdf: {source}",
+                    f"    target_rdf: {target}",
+                    f"    alignment_rdf: {alignment}",
+                    "heldout_secondary_datasets:",
+                    "  class_fixture:",
+                    "    track: bioml-supervised",
+                    '    version: "2022"',
+                    f"    source_rdf: {source}",
+                    f"    target_rdf: {target}",
+                    f"    alignment_rdf: {alignment}",
+                    "heldout:",
+                    "  selection:",
+                    "    metric: mrr",
+                    "    lambda: 0.5",
+                    "    weighting: equal_track_weight",
+                    "    ranking: per_track_normalized_rank",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return config_path
+
+    def _write_selected_settings(self, path: Path) -> None:
+        payload = {
+            "selected_settings": {
+                "tfidf": {
+                    "method": "tfidf",
+                    "hyperparameters": {
+                        "ngram_range": [1, 1],
+                        "min_df": 1,
+                        "max_df": 1.0,
+                        "sublinear_tf": False,
+                    },
+                },
+                "bm25": {
+                    "method": "bm25",
+                    "hyperparameters": {"k1": 1.7, "b": 0.75},
+                },
+            }
+        }
+        path.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+
+    def test_runner_generates_class_only_rows_for_all_methods(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config = self._write_config(tmp)
+            selected = tmp / "heldout_selected_settings.json"
+            output_csv = tmp / "results" / "heldout_class.csv"
+            self._write_selected_settings(selected)
+
+            results = run_heldout_class_experiments(
+                config_path=config,
+                selected_settings_path=selected,
+                output_csv_path=output_csv,
+                show_progress=False,
+            )
+
+        self.assertEqual(len(results), 4)
+        self.assertEqual({row["entity_type"] for row in results}, {"class"})
+        self.assertEqual(
+            {row["model"] for row in results},
+            {"tfidf", "bm25", "exact_match", "char_ngram"},
+        )
+        with output_csv.open("r", encoding="utf-8", newline="") as csv_file:
+            rows = list(csv.DictReader(csv_file))
+        self.assertEqual(len(rows), 4)
+        self.assertEqual({row["entity_type"] for row in rows}, {"class"})
+
+    def test_runner_uses_selected_settings_only_for_tunable_methods(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config = self._write_config(tmp)
+            selected = tmp / "heldout_selected_settings.json"
+            self._write_selected_settings(selected)
+
+            results = run_heldout_class_experiments(
+                config_path=config,
+                selected_settings_path=selected,
+                show_progress=False,
+            )
+
+        tfidf_row = next(row for row in results if row["model"] == "tfidf")
+        bm25_row = next(row for row in results if row["model"] == "bm25")
+        exact_row = next(row for row in results if row["model"] == "exact_match")
+        self.assertEqual(tfidf_row["hyperparameters"]["ngram_range"], [1, 1])
+        self.assertEqual(bm25_row["hyperparameters"], {"k1": 1.7, "b": 0.75})
+        self.assertEqual(exact_row["hyperparameters"], {"normalization": "light_v1"})
+
+    def test_runner_fails_when_class_targets_are_missing(self) -> None:
+        empty_target = """<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" />
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config = self._write_config(tmp, target_rdf_text=empty_target)
+            selected = tmp / "heldout_selected_settings.json"
+            self._write_selected_settings(selected)
+            with self.assertRaises(HeldoutClassRunnerValidationError):
+                run_heldout_class_experiments(
+                    config_path=config,
+                    selected_settings_path=selected,
+                    show_progress=False,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -505,6 +505,39 @@ heldout:
         self.assertIn("Error: ValueError: bad heldout reporting input", stderr.getvalue())
         self.assertIn("CLI execution failed", "\n".join(captured.output))
 
+    def test_report_heldout_class_explicit_args(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            results_csv = tmp / "heldout_class_result_fixture.csv"
+            selected_json = tmp / "heldout_selected_settings.json"
+            output_dir = tmp / "comparisons"
+            stdout = io.StringIO()
+
+            with patch(
+                "src.main.generate_class_heldout_reporting",
+                return_value={"output_dir": output_dir},
+            ) as report_mock:
+                with contextlib.redirect_stdout(stdout):
+                    exit_code = main(
+                        [
+                            "report-heldout-class",
+                            "--results-csv",
+                            str(results_csv),
+                            "--selected-settings-json",
+                            str(selected_json),
+                            "--output-dir",
+                            str(output_dir),
+                        ]
+                    )
+
+            self.assertEqual(exit_code, 0)
+            report_mock.assert_called_once_with(
+                results_csv_path=str(results_csv),
+                output_dir=str(output_dir),
+                selected_settings_path=str(selected_json),
+            )
+            self.assertIn(f"Held-Out Class-Only Report Dir: {output_dir}", stdout.getvalue())
+
     def test_run_heldout_kg_explicit_args(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
@@ -582,6 +615,92 @@ heldout:
         self.assertEqual(exit_code, 1)
         self.assertIn("Error: ValueError: bad heldout kg input", stderr.getvalue())
         self.assertIn("CLI execution failed", "\n".join(captured.output))
+
+    def test_run_heldout_class_explicit_args(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            output_csv = tmp / "heldout_class.csv"
+            stdout = io.StringIO()
+
+            with patch("src.main.run_heldout_class_experiments", return_value=[]) as heldout_mock:
+                output_csv.write_text("track,version\n", encoding="utf-8")
+                with contextlib.redirect_stdout(stdout):
+                    exit_code = main(
+                        [
+                            "run-heldout-class",
+                            "--config-path",
+                            str(tmp / "runtime.yaml"),
+                            "--selected-settings-json",
+                            str(tmp / "heldout_selected_settings.json"),
+                            "--output-csv-path",
+                            str(output_csv),
+                        ]
+                    )
+
+            self.assertEqual(exit_code, 0)
+            heldout_mock.assert_called_once_with(
+                config_path=str(tmp / "runtime.yaml"),
+                selected_settings_path=str(tmp / "heldout_selected_settings.json"),
+                output_csv_path=str(output_csv),
+                show_progress=None,
+            )
+            self.assertIn(f"Held-Out Class-Only Results CSV: {output_csv}", stdout.getvalue())
+
+    def test_heldout_class_full_run_wires_same_run_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            selected_settings = tmp / "comparisons" / "result_dev" / "heldout_selected_settings.json"
+            selected_settings.parent.mkdir(parents=True, exist_ok=True)
+            selected_settings.write_text('{"source_csv": "/tmp/dev.csv"}\n', encoding="utf-8")
+            heldout_csv = tmp / "results" / "heldout_class_result_fixture.csv"
+            heldout_csv.parent.mkdir(parents=True, exist_ok=True)
+            heldout_csv.write_text("track,version\n", encoding="utf-8")
+            report_output_dir = tmp / "comparisons" / "heldout_class_result_fixture"
+            report_output_dir.mkdir(parents=True, exist_ok=True)
+
+            with patch(
+                "src.main.generate_heldout_selection",
+                return_value={
+                    "source_csv": tmp / "results" / "result_dev.csv",
+                    "heldout_selected_settings": selected_settings,
+                },
+            ) as selection_mock:
+                with patch("src.main.run_heldout_class_experiments", return_value=[]) as heldout_mock:
+                    with patch(
+                        "src.main._resolve_new_heldout_class_result_file",
+                        return_value=heldout_csv.resolve(),
+                    ):
+                        with patch(
+                            "src.main.generate_class_heldout_reporting",
+                            return_value={"output_dir": report_output_dir},
+                        ) as report_mock:
+                            exit_code = main(
+                                [
+                                    "heldout-class-full-run",
+                                    "--config-path",
+                                    str(tmp / "runtime.yaml"),
+                                    "--dev-results-csv",
+                                    str(tmp / "results" / "result_dev.csv"),
+                                    "--output-dir",
+                                    str(tmp / "comparisons"),
+                                ]
+                            )
+
+            self.assertEqual(exit_code, 0)
+            selection_mock.assert_called_once()
+            heldout_mock.assert_called_once_with(
+                config_path=str(tmp / "runtime.yaml"),
+                selected_settings_path=selected_settings.resolve(),
+                output_csv_path=None,
+                show_progress=None,
+            )
+            report_mock.assert_called_once_with(
+                results_csv_path=heldout_csv.resolve(),
+                output_dir=str(tmp / "comparisons"),
+                selected_settings_path=selected_settings.resolve(),
+            )
+            manifest_path = report_output_dir / "heldout_class_full_run_manifest.txt"
+            self.assertTrue(manifest_path.exists())
 
     def test_heldout_full_run_wires_same_run_artifacts_and_writes_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1070,8 +1189,11 @@ heldout:
         self.assertIn("bm25-sensitivity", help_text)
         self.assertIn("select-heldout-settings", help_text)
         self.assertIn("report-heldout-kg", help_text)
+        self.assertIn("report-heldout-class", help_text)
         self.assertIn("run-heldout-kg", help_text)
+        self.assertIn("run-heldout-class", help_text)
         self.assertIn("heldout-full-run", help_text)
+        self.assertIn("heldout-class-full-run", help_text)
         self.assertIn("full-run", help_text)
         self.assertIn("run", help_text)
 


### PR DESCRIPTION
## Summary
- add class-only held-out runner and reporting pipeline
- add class-only CLI commands and full-run orchestrator
- extend config to support heldout_secondary_datasets
- update docs and tests for class-only workflow
- tighten class-only execution to avoid non-class partitions

## Testing
- .venv/bin/python -m src.main run-heldout-class --config-path config/runtime.yaml

Closes #48
